### PR TITLE
fix: Deduplicate relative links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,11 +60,12 @@ RSpec/NestedGroups:
   Max: 4
 RSpec/ContextWording:
   Prefixes:
-    - when
     - and
+    - for
+    - when
     - with
     - without
-    - for
+    - returns
 
 Style/StringLiterals:
   EnforcedStyle: "double_quotes"

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,4 +1,6 @@
 Link = Data.define(:href, :text) do
+  include Comparable
+
   class << self
     def from(source)
       case source
@@ -26,6 +28,7 @@ Link = Data.define(:href, :text) do
   end
 
   delegate :normalize, to: :class
+  delegate :hash, to: :href
 
   def initialize(href:, text: nil)
     super(href: normalize(href).to_s, text: text&.squish || "")
@@ -33,4 +36,6 @@ Link = Data.define(:href, :text) do
 
   def to_str = href
   def ==(other) = href == other.to_str
+  def <=>(other) = other.is_a?(Link) ? href <=> other.href : nil
+  def eql?(other) = other.is_a?(Link) && href == other.href
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,16 +1,36 @@
 Link = Data.define(:href, :text) do
-  def initialize(href:, text: nil)
-    super(href: href.to_s, text: text&.squish || "")
-  end
+  class << self
+    def from(source)
+      case source
+      when Link then source
+      when String, URI then Link.new(href: source)
+      else raise ArgumentError.new("#{source.class.name} is not allowed in Link.from")
+      end
+    end
 
-  def self.from(source)
-    case source
-    when Link then source
-    when String, URI then Link.new(href: source)
-    else raise ArgumentError.new("#{source.class.name} is not allowed in Link.from")
+    def normalize(href)
+      uri = URI.parse(href.dup)
+      uri.fragment = nil # Fragments shouldn't change the target document
+
+      return uri if uri.relative?
+      return URI.join(uri, "/") if uri.path.empty?
+
+      origin = uri.origin
+      origin = "#{origin}/" unless origin.end_with?("/") # Ensure the origin ends with a slash for proper joining
+      normalized_path = File.expand_path(uri.path, "/")
+      normalized_path = normalized_path[1..-1] if normalized_path.start_with?("/")
+      query = uri.query.nil? ? "" : "?#{uri.query}"
+
+      URI.join(origin, normalized_path) + query
     end
   end
 
+  delegate :normalize, to: :class
+
+  def initialize(href:, text: nil)
+    super(href: normalize(href).to_s, text: text&.squish || "")
+  end
+
   def to_str = href
-  def ==(other) = href == other
+  def ==(other) = href == other.to_str
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -34,7 +34,7 @@ class Page
   def inspect =  "#<#{self.class.name} @url=#{url.inspect} @title=#{title}>"
   def success? = status == 200
   def error? = status > 399
-  def refresh = Rails.cache.clear(url) && fetch
+  def refresh = fetch(clear: true)
 
   def dom
     Nokogiri::HTML(html)
@@ -59,7 +59,8 @@ class Page
 
   private
 
-  def fetch
+  def fetch(clear: false)
+    Rails.cache.clear(url) if clear
     Rails.cache.fetch(url, expires_in: CACHE_TTL) do
       @actual_url, @status, @headers, @html = Browser.get(url.to_s).values_at(:current_url, :status, :headers, :body)
       content_type = headers["Content-Type"]

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -22,8 +22,8 @@ class Page
     @html = html || fetch&.last
   end
 
-  def path = url.to_s.delete_prefix(root.to_s)
   def root? = url == root
+  def path = url.to_s.delete_prefix(root.to_s)
   def redirected? = actual_url.present? && actual_url != url
   def css(selector) = dom.css(selector)
   def title = dom.title&.squish

--- a/spec/models/link_list_spec.rb
+++ b/spec/models/link_list_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe LinkList do
   describe "#to_a" do
     it "returns an array of hrefs" do
       list = described_class.new(link1, link2)
-      expect(list.to_a).to eq(["https://example1.com", "https://example2.com"])
+      expect(list.to_a).to eq(["https://example1.com/", "https://example2.com/"])
     end
   end
 

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -164,4 +164,78 @@ RSpec.describe Link do
       end
     end
   end
+
+  describe "#<=>" do
+    it "allows sorting by href" do
+      links = [
+        described_class.new(href: "http://example.com/c.html"),
+        described_class.new(href: "http://example.com/a.html"),
+        described_class.new(href: "http://example.com/b.html")
+      ]
+
+      sorted = links.sort
+      expect(sorted.map(&:href)).to eq([
+        "http://example.com/a.html",
+        "http://example.com/b.html",
+        "http://example.com/c.html"
+      ])
+    end
+  end
+
+  describe "#eql?" do
+    it "deduplicates identical links with uniq" do
+      links = [
+        described_class.new(href: "http://example.com/page.html"),
+        described_class.new(href: "http://example.com/page.html"),
+        described_class.new(href: "http://example.com/page.html")
+      ]
+
+      unique_links = links.uniq
+      expect(unique_links.size).to eq(1)
+    end
+
+    it "deduplicates links that normalize to the same URL" do
+      links = [
+        described_class.new(href: "http://example.com/page.html"),
+        described_class.new(href: "http://example.com/folder/../page.html"),
+        described_class.new(href: "http://example.com/./page.html")
+      ]
+
+      unique_links = links.uniq
+      expect(unique_links.size).to eq(1)
+    end
+
+    it "works correctly with Set" do
+      links = [
+        described_class.new(href: "http://example.com/page1.html"),
+        described_class.new(href: "http://example.com/page1.html"),
+        described_class.new(href: "http://example.com/page2.html")
+      ]
+
+      set = Set.new(links)
+      expect(set.size).to eq(2)
+    end
+
+    it "works correctly with Hash keys" do
+      link1 = described_class.new(href: "http://example.com/page.html")
+      link2 = described_class.new(href: "http://example.com/folder/../page.html")
+
+      hash = { link1 => "value1" }
+      hash[link2] = "value2"
+
+      expect(hash.size).to eq(1)
+      expect(hash[link1]).to eq("value2")
+    end
+
+    it "deduplicates but preserves text from the first occurrence" do
+      links = [
+        described_class.new(href: "http://example.com/page.html", text: "First text"),
+        described_class.new(href: "http://example.com/page.html", text: "Second text")
+      ]
+
+      unique_links = links.uniq
+      expect(unique_links.size).to eq(1)
+      expect(unique_links.first.text).to eq("First text")
+    end
+  end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,16 +1,114 @@
 require "rails_helper"
 
 RSpec.describe Link do
+  describe ".normalize" do
+    it "removes fragments from URLs" do
+      normalized = described_class.normalize("http://example.com/page#section")
+      expect(normalized.to_s).not_to include("#section")
+    end
+
+    it "preserves query parameters" do
+      normalized = described_class.normalize("http://example.com/page?param=value")
+      expect(normalized.to_s).to include("?param=value")
+    end
+
+    it "normalizes paths with parent directory references" do
+      normalized = described_class.normalize("http://example.com/folder/../page.html")
+      expect(normalized.to_s).to eq("http://example.com/page.html")
+    end
+
+    it "normalizes paths with current directory references" do
+      normalized = described_class.normalize("http://example.com/folder/./page.html")
+      expect(normalized.to_s).to eq("http://example.com/folder/page.html")
+    end
+
+    it "normalizes paths with multiple parent directory references" do
+      normalized = described_class.normalize("http://example.com/a/b/c/../../page.html")
+      expect(normalized.to_s).to eq("http://example.com/a/page.html")
+    end
+
+    it "normalizes complex paths with mixed parent and current directory references" do
+      normalized = described_class.normalize("http://example.com/a/./b/../c/./d/../page.html")
+      expect(normalized.to_s).to eq("http://example.com/a/c/page.html")
+    end
+
+    it "handles non-standard ports" do
+      normalized = described_class.normalize("http://example.com:8080/page.html")
+      expect(normalized.to_s).to include(":8080")
+    end
+
+    it "doesn't include standard ports in the normalized URL" do
+      normalized = described_class.normalize("http://example.com:80/page.html")
+      expect(normalized.to_s).not_to include(":80")
+    end
+
+    it "handles URLs with no path" do
+      normalized = described_class.normalize("http://example.com")
+      expect(normalized.to_s).to eq("http://example.com/")
+    end
+
+    it "normalizes redundant slashes" do
+      normalized = described_class.normalize("http://example.com//folder///page.html")
+      expect(normalized.to_s).to eq("http://example.com/folder/page.html")
+    end
+
+    it "handles URLs with paths that attempt to go above root" do
+      normalized = described_class.normalize("http://example.com/a/../../../page.html")
+      expect(normalized.to_s).to eq("http://example.com/page.html")
+    end
+
+    it "normalizes URLs with encoded characters" do
+      normalized = described_class.normalize("http://example.com/folder/page%20with%20spaces.html")
+      expect(normalized.to_s).to eq("http://example.com/folder/page%20with%20spaces.html")
+    end
+
+    it "preserves URL-encoded characters in paths" do
+      normalized = described_class.normalize("http://example.com/%C3%A9t%C3%A9.html")
+      expect(normalized.to_s).to eq("http://example.com/%C3%A9t%C3%A9.html")
+    end
+
+    it "treats URLs as equal if they refer to the same document" do
+      url1 = described_class.normalize("http://example.com/path/page")
+      url2 = described_class.normalize("http://example.com/path/page/")
+      expect(url1.to_s).to eq(url2.to_s)
+    end
+
+    it "preserves the original scheme" do
+      normalized = described_class.normalize("https://example.com/page.html")
+      expect(normalized.to_s).to start_with("https://")
+    end
+
+    context "when normalizing different URLs that refer to the same resource" do
+      let(:urls) do
+        [
+          "http://example.com/folder/page.html",
+          "http://example.com/folder/../folder/page.html",
+          "http://example.com/folder/./page.html",
+          "http://example.com//folder/page.html",
+          "http://example.com/folder//page.html",
+          "http://example.com/folder/other/../page.html"
+        ]
+      end
+
+      it "normalizes all equivalent URLs to the same form" do
+        normalized_urls = urls.map { |url| described_class.normalize(url).to_s }
+        expect(normalized_urls.uniq.size).to eq(1)
+        expect(normalized_urls.first).to eq("http://example.com/folder/page.html")
+      end
+    end
+  end
+
   describe "#initialize" do
     it "creates a Link with href and text" do
       link = described_class.new(href: "https://example.com", text: "Example")
-      expect(link.href).to eq("https://example.com")
+      expect(link.href).to eq("https://example.com/")
       expect(link.text).to eq("Example")
     end
 
     it "converts href to string" do
-      link = described_class.new(href: URI("https://example.com"), text: "Example")
-      expect(link.href).to eq("https://example.com")
+      link = described_class.new(href: URI("https://example.com/"), text: "Example")
+      expect(link.href).to be_a(String)
+      expect(link.href).to eq("https://example.com/")
     end
 
     it "squishes text" do
@@ -26,22 +124,44 @@ RSpec.describe Link do
 
   describe "#to_str" do
     it "returns the href" do
-      link = described_class.new(href: "https://example.com", text: "Example")
-      expect(link.to_str).to eq("https://example.com")
+      link = described_class.new(href: "https://example.com/", text: "Example")
+      expect(link.to_str).to eq("https://example.com/")
     end
   end
 
   describe "#==" do
-    it "considers links equal if they have the same href" do
-      link1 = described_class.new(href: "https://example.com", text: "Example 1")
-      link2 = described_class.new(href: "https://example.com", text: "Example 2")
-      expect(link1).to eq(link2)
+    context "returns true" do
+      it "if they have the same href" do
+        link1 = described_class.new(href: "https://example.com/", text: "Example 1")
+        link2 = described_class.new(href: "https://example.com/", text: "Example 2")
+        expect(link1).to eq(link2)
+      end
+
+      it "if only the #fragment part of the href differ" do
+        link1 = described_class.new(href: "https://example.com/path#fragment1", text: "Example 1")
+        link2 = described_class.new(href: "https://example.com/path#fragment2", text: "Example 2")
+        expect(link1).to eq(link2)
+      end
+
+      it "if relative parts resolve to the same href" do
+        link1 = described_class.new(href: "https://example.com/path", text: "Example 1")
+        link2 = described_class.new(href: "https://example.com/other/../path/", text: "Example 2")
+        expect(link1).to eq(link2)
+      end
     end
 
-    it "considers links different if they have different hrefs" do
-      link1 = described_class.new(href: "https://example1.com", text: "Example")
-      link2 = described_class.new(href: "https://example2.com", text: "Example")
-      expect(link1).not_to eq(link2)
+    context "returns false" do
+      it "if the hosts are different" do
+        link1 = described_class.new(href: "https://example1.com/", text: "Example")
+        link2 = described_class.new(href: "https://example2.com/", text: "Example")
+        expect(link1).not_to eq(link2)
+      end
+
+      it "if the paths are different" do
+        link1 = described_class.new(href: "https://example.com/", text: "Example")
+        link2 = described_class.new(href: "https://example.com/path/to/file", text: "Example")
+        expect(link1).not_to eq(link2)
+      end
     end
   end
 end


### PR DESCRIPTION
Relative links pointing to the same location would be considered different, leading to crawling the same page several times.
Now `/a/../b` correctly resolves to `/b`, `//path` to `/path`, etc.