### PR TITLE
feat: Audit asynchronously

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -22,7 +22,7 @@ class SitesController < ApplicationController
   def create
     @site = Site.find_or_create_by_url(site_params)
     if @site.persisted?
-      @site.audit.run! if @site.audit.pending?
+      @site.audit.schedule if @site.audit.pending?
       redirect_to @site, notice: t(".notice")
     else
       render :new, status: :unprocessable_entity

--- a/app/jobs/run_audit_job.rb
+++ b/app/jobs/run_audit_job.rb
@@ -1,0 +1,5 @@
+class RunAuditJob < ApplicationJob
+  def perform(audit)
+    audit.all_checks.each { |check| check.schedule! }
+  end
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -25,6 +25,7 @@ class Audit < ApplicationRecord
   def parsed_url = @parsed_url ||= URI.parse(url).normalize
   def url_without_scheme = @url_without_scheme ||= [hostname, path == "/" ? nil : path].compact.join(nil)
   def checks = Check.find_by(audit: self)
+  def schedule = RunAuditJob.perform_later(self)
 
   def all_checks
     Check.names.map { |name| send(name) || send(:"build_#{name}") }

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -24,6 +24,7 @@ class Audit < ApplicationRecord
 
   def parsed_url = @parsed_url ||= URI.parse(url).normalize
   def url_without_scheme = @url_without_scheme ||= [hostname, path == "/" ? nil : path].compact.join(nil)
+  def checks = Check.find_by(audit: self)
 
   def all_checks
     Check.names.map { |name| send(name) || send(:"build_#{name}") }

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -36,12 +36,6 @@ class Audit < ApplicationRecord
     all_checks
   end
 
-  def run!
-    all_checks.each(&:run)
-    derive_status_from_checks
-    set_checked_at
-  end
-
   def check_status(check)
     (send(check)&.status || :pending).to_s.inquiry
   end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -58,7 +58,7 @@ class Audit < ApplicationRecord
   end
 
   def set_checked_at
-    latest_checked_at = all_checks.collect(&:checked_at).sort.last
+    latest_checked_at = checks.collect(&:checked_at).compact.sort.last
     update(checked_at: latest_checked_at)
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -44,6 +44,6 @@ class Site < ApplicationRecord
   def should_generate_new_friendly_id? = new_record? || (audit && slug != url_without_scheme.parameterize)
 
   def audit!
-    audits.create(url:).tap(&:run!).tap(&:persisted?)
+    audits.create(url:).tap(&:schedule).tap(&:persisted?)
   end
 end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -197,11 +197,11 @@ RSpec.describe Check do
     context "when check is waiting on requirements" do
       before do
         allow(check).to receive(:waiting?).and_return(true)
-        allow(check).to receive(:reschedule!)
+        allow(check).to receive(:schedule!)
       end
 
-      it "reschedules the check" do
-        expect(check).to receive(:reschedule!)
+      it "schedules the check" do
+        expect(check).to receive(:schedule!)
         check.run
       end
 


### PR DESCRIPTION
Avoid timeouts when running all checks simultaneously