### PR TITLE
Feat: Add icon helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,25 @@ module ApplicationHelper
     content_tag(tag, text, **options, &block)
   end
 
+  def icon_class(*icon, fill: true, **options)
+    icon = Array.wrap(icon).join("-")
+    fill = options[:line] || !fill ? "line" : "fill"
+    side = options[:side].to_s.to_sym.presence_in([:left, :right])
+    size = options[:size].to_s.to_sym.presence_in([:sm, :lg])
+    btn = (options[:button] || options[:btn])
+    link = !btn && side
+    class_names(
+      options[:class],
+      "fr-link" => link,
+      "fr-link--#{size}" => link && size,
+      "fr-link--icon-#{side}" => link && side,
+      "fr-btn" => btn,
+      "fr-btn--#{size}" => btn && size,
+      "fr-btn--icon-#{side}" => btn && side,
+      "fr-icon-#{icon}-#{fill}" => icon.present?,
+    )
+  end
+
   def sort_link(text, param, **options)
     permitted_params = params.permit(:page)
     current_sort = params.dig(:sort, param)&.downcase&.to_sym

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,6 +53,8 @@ module ApplicationHelper
     side = options[:side].to_s.to_sym.presence_in([:left, :right])
     size = options[:size].to_s.to_sym.presence_in([:sm, :lg])
     btn = (options[:button] || options[:btn])
+    btn_style = btn && btn.to_s.to_sym.presence_in([:primary, :secondary, :tertiary])
+    btn_style = "tertiary-no-outline" if btn_style == :tertiary && options[:outline] == false
     link = !btn && side
     class_names(
       options[:class],
@@ -61,9 +63,17 @@ module ApplicationHelper
       "fr-link--icon-#{side}" => link && side,
       "fr-btn" => btn,
       "fr-btn--#{size}" => btn && size,
+      "fr-btn--#{btn_style}" => btn_style,
       "fr-btn--icon-#{side}" => btn && side,
       "fr-icon-#{icon}-#{fill}" => icon.present?,
     )
+  end
+
+  def link_icon(icon, name = nil, options = {}, html_options = {}, &block)
+    html_options, options, name = options, name, block.call if block_given?
+    icon_options = html_options.extract!(:fill, :line, :side, :size, :button, :btn, :outline, :class)
+    html_options[:class] = icon_class(icon, **icon_options)
+    link_to(name, options, html_options)
   end
 
   def sort_link(text, param, **options)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,16 +77,16 @@ module ApplicationHelper
   end
 
   def sort_link(text, param, **options)
-    permitted_params = params.permit(:page)
     current_sort = params.dig(:sort, param)&.downcase&.to_sym
     direction = current_sort == :asc ? :desc : :asc
-    link_params = permitted_params.merge(sort: { param => direction })
-    options[:class] = class_names(
-      options.delete(:class),
-      "fr-link fr-link--icon-right fr-icon-arrow-#{direction == :asc ? :down : :up}-s-fill" => current_sort.present?
-    ).presence
+    link_params = params.permit(:page).merge(sort: { param => direction })
+    if current_sort.present?
+      options[:class] = icon_class(:arrow, direction == :asc ? :down : :up, :s,
+                                   side: :right,
+                                   class: options.delete(:class))
+    end
     options[:title] ||= t("shared.sort_by", column: text, direction: t("shared.#{direction}"))
-    link_to text, url_for(params: link_params), **options
+    link_to text, { params: link_params }, **options
   end
 
   def root? = request.path == "/"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,16 @@ module ApplicationHelper
     render Dsfr::PaginationComponent.new(pagy: @pagy)
   end
 
+  def icon(*icon, fill: true, **options, &block)
+    icon = Array.wrap(icon).join("-")
+    fill = options[:line] || !fill ? "line" : "fill"
+    tag = options[:tag] || :span
+    options[:class] = class_names(options[:class], "fr-icon-#{icon}-#{fill}")
+    options[:aria] = { hidden: true }.merge(options[:aria] || {})
+    text = options.delete(:text)
+    content_tag(tag, text, **options, &block)
+  end
+
   def sort_link(text, param, **options)
     permitted_params = params.permit(:page)
     current_sort = params.dig(:sort, param)&.downcase&.to_sym

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -12,7 +12,7 @@
   <% t.with_body do %>
     <% @sites.each do |site| %>
       <tr>
-        <td class="fr-cell--center"><%= link_to(site, title: Site.human(:view_name, name: site.name), class: "fr-link fr-icon-article-line fr-link--icon-left link--icon-only") { tag.span(class: "fr-sr-only") { Site.human(:view) } } %></td>
+        <td class="fr-cell--center"><%= link_icon(:article, site, title: Site.human(:view_name, name: site.name), line: true, side: :left, class: "link--icon-only") { tag.span(class: "fr-sr-only") { Site.human(:view) } } %></td>
         <td><%= link_to site.url_without_scheme, site.url, target: :_blank %></td>
         <% site.audit.all_checks.each do |check| %>
           <td class="fr-cell--center"><%= check.blocked? || check.pending? ? "-" : badge(check.to_badge, tooltip: true) %></td>
@@ -30,6 +30,6 @@
     <% end %>
   <% end %>
   <% t.with_footer_action do %>
-    <%= link_to Site.human(:export_to_csv), url_for(format: :csv), class: "fr-btn fr-icon-file-download-fill", data: { "turbo-prefetch": false } %>
+    <%= link_icon "file-download", Site.human(:export_to_csv), url_for(format: :csv), btn: :secondary, data: { "turbo-prefetch": false } %>
   <% end %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -141,4 +141,61 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(result).to include("custom-class")
     end
   end
+
+  describe "#link_icon" do
+    context "with name and options arguments" do
+      it "generates a link with icon classes" do
+        result = helper.link_icon(:arrow, "Next Page", "/next", side: :right)
+
+        expect(result).to have_selector("a[href='/next']")
+        expect(result).to have_selector("a.fr-link.fr-link--icon-right.fr-icon-arrow-fill")
+        expect(result).to have_content("Next Page")
+      end
+
+      it "supports line style" do
+        result = helper.link_icon(:arrow, "Next", "/next", line: true)
+
+        expect(result).to have_selector("a.fr-icon-arrow-line")
+      end
+
+      it "supports size option" do
+        result = helper.link_icon(:arrow, "Next", "/next", side: :right, size: :sm)
+
+        expect(result).to have_selector("a.fr-link--sm")
+      end
+
+      it "supports button styling" do
+        result = helper.link_icon(:arrow, "Next", "/next", button: true)
+
+        expect(result).to have_selector("a.fr-btn")
+        expect(result).not_to have_selector("a.fr-link")
+      end
+
+      it "merges custom classes" do
+        result = helper.link_icon(:arrow, "Next", "/next", class: "my-custom-class")
+
+        expect(result).to have_selector("a.my-custom-class")
+        expect(result).to have_selector("a.fr-icon-arrow-fill")
+      end
+    end
+
+    context "with block syntax" do
+      it "generates a link with block content" do
+        result = helper.link_icon(:arrow, "/next", side: :right) do
+          helper.content_tag(:span, "Next Page", class: "visually-hidden")
+        end
+
+        expect(result).to have_selector("a[href='/next']")
+        expect(result).to have_selector("a.fr-link.fr-link--icon-right.fr-icon-arrow-fill")
+        expect(result).to have_selector("a span.visually-hidden", text: "Next Page")
+      end
+
+      it "supports all icon options with block syntax" do
+        result = helper.link_icon(:download, "/file", button: true, size: :lg, side: :left) { "Download File" }
+
+        expect(result).to have_selector("a.fr-btn.fr-btn--lg.fr-btn--icon-left.fr-icon-download-fill")
+        expect(result).to have_content("Download File")
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#icon" do
+    it "handles any number of icon segments", :aggregate_failures do
+      selector = ".fr-icon-user-fill"
+      expect(helper.icon("user")).to have_selector(selector)
+      expect(helper.icon(:user)).to have_selector(selector)
+
+      selector = ".fr-icon-arrow-right-s-fill"
+      expect(helper.icon("arrow", "right", "s")).to have_selector(selector)
+      expect(helper.icon(["arrow", "right", "s"])).to have_selector(selector)
+    end
+
+    it "adds fill style unless told otherwise", :aggregate_failures do
+      user_fill = ".fr-icon-user-fill"
+      expect(helper.icon("user")).to have_selector(user_fill)
+      expect(helper.icon("user", fill: true)).to have_selector(user_fill)
+
+      user_line = ".fr-icon-user-line"
+      expect(helper.icon("user", line: true)).to have_selector(user_line)
+      expect(helper.icon("user", fill: false)).to have_selector(user_line)
+      expect(helper.icon("user", line: true, fill: true)).to have_selector(user_line)
+    end
+
+    it "allows changing the tag", :aggregate_failures do
+      expect(helper.icon("user")).to have_selector("span")
+      expect(helper.icon("user", tag: :i)).to have_selector("i")
+      expect(helper.icon("user", tag: "div")).to have_selector("div")
+    end
+
+    it "accepts additional HTML options", :aggregate_failures do
+      expect(helper.icon("user", class: "custom-class")).to have_selector(".fr-icon-user-fill.custom-class")
+
+      result = helper.icon("user", id: "icon-id", data: { test: "value" })
+      expect(result).to have_selector("#icon-id[data-test='value']")
+    end
+
+    it "has aria-hidden: true, but allows overrides and additions", :aggregate_failures do
+      expect(helper.icon("user")).to have_selector("[aria-hidden='true']")
+
+      result = helper.icon("user", aria: { hidden: false })
+      expect(result).to have_selector("span[aria-hidden='false']")
+
+      result = helper.icon("user", aria: { label: "User icon" })
+      expect(result).to have_selector("span[aria-hidden='true'][aria-label='User icon']")
+    end
+
+    it "accepts text as an option or a block", :aggregate_failures do
+      result = helper.icon("user", text: "User Account")
+      expect(result).to have_selector("span", text: "User Account")
+
+      result = helper.icon("user", text: "<strong>User</strong>".html_safe)
+      expect(result).to have_selector("span strong", text: "User")
+
+      result = helper.icon("user") { "<strong>User</strong>".html_safe }
+      expect(result).to have_selector("span strong", text: "User")
+
+      result = helper.icon("user", text: "Option Text") { "Block Text" }
+      expect(result).to have_text("Block Text")
+      expect(result).not_to have_text("Option Text")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -63,4 +63,82 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(result).not_to have_text("Option Text")
     end
   end
+
+  describe "#icon_class" do
+    it "handles any number of icon segments", :aggregate_failures do
+      classes = "fr-icon-user-fill"
+      expect(helper.icon_class("user")).to eq(classes)
+      expect(helper.icon_class(:user)).to eq(classes)
+
+      classes = "fr-icon-arrow-right-s-fill"
+      expect(helper.icon_class("arrow", "right", "s")).to eq(classes)
+      expect(helper.icon_class(["arrow", "right", "s"])).to eq(classes)
+    end
+
+    it "adds fill style unless told otherwise", :aggregate_failures do
+      user_fill = "fr-icon-user-fill"
+      expect(helper.icon_class("user")).to eq(user_fill)
+      expect(helper.icon_class("user", fill: true)).to eq(user_fill)
+
+      user_line = "fr-icon-user-line"
+      expect(helper.icon_class("user", line: true)).to eq(user_line)
+      expect(helper.icon_class("user", fill: false)).to eq(user_line)
+      expect(helper.icon_class("user", line: true, fill: true)).to eq(user_line)
+    end
+
+    context "with side option" do
+      it "adds link classes when side is specified", :aggregate_failures do
+        expect(helper.icon_class(:arrow, side: :right)).to include("fr-link")
+        expect(helper.icon_class(:arrow, side: :right)).to include("fr-link--icon-right")
+        expect(helper.icon_class(:arrow, side: "right")).to include("fr-link--icon-right")
+      end
+
+      it "adds size modifier when provided" do
+        expect(helper.icon_class(:arrow, side: :right, size: :sm)).to include("fr-link--sm")
+      end
+
+      it "ignores invalid side values" do
+        expect(helper.icon_class(:arrow, side: :top)).not_to include("fr-link--icon")
+      end
+
+      it "ignores invalid size values" do
+        expect(helper.icon_class(:arrow, side: :right, size: :xl)).not_to include("fr-link--xl")
+      end
+    end
+
+    context "with button/btn option" do
+      it "adds button classes when button: true is passed" do
+        expect(helper.icon_class(:user, btn: true)).to include("fr-btn")
+        expect(helper.icon_class(:user, button: true)).to include("fr-btn")
+        expect(helper.icon_class(:user, button: true)).not_to include("fr-link")
+      end
+
+      it "adds size modifier when provided" do
+        expect(helper.icon_class(:arrow, button: true, size: :sm)).to include("fr-btn--sm")
+      end
+
+      it "adds side modifier when provided" do
+        expect(helper.icon_class(:arrow, button: true, side: :right)).to include("fr-btn--icon-right")
+      end
+
+      it "ignores invalid side values" do
+        expect(helper.icon_class(:arrow, button: true, side: :top)).not_to include("fr-btn--icon")
+      end
+
+      it "ignores invalid size values" do
+        expect(helper.icon_class(:arrow, button: true, side: :right, size: :xl)).not_to include("fr-btn--xl")
+      end
+
+      it "prioritizes button over link when both options are passed" do
+        result = helper.icon_class(:arrow, button: true, side: :right)
+        expect(result).to include("fr-btn--icon-right")
+        expect(result).not_to include("fr-link")
+      end
+    end
+
+    it "accepts a class option" do
+      result = helper.icon_class(:arrow, class: "custom-class")
+      expect(result).to include("custom-class")
+    end
+  end
 end


### PR DESCRIPTION
- `icon` to insert an icon. Tag option defaults to `span` with `aria-hidden: true`.
- `link_icon` to generate links. Accepts `size` and `btn` options (`true/primary/secondary/tertiary`).
- and an `icon_class` base helper, which accepts `size`, `side`, and `fill/line` options.
