### PR TITLE
refactor: Simplify association between site and current audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,6 @@ gem "sentry-rails"
 # Allow I18N URLs
 gem "addressable", "~> 2.8"
 
-# Add optimized Active Record association methods
-gem "activerecord-has_some_of_many"
-
 # Pagination
 gem "pagy"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,9 +53,6 @@ GEM
       activemodel (= 8.0.2)
       activesupport (= 8.0.2)
       timeout (>= 0.4.0)
-    activerecord-has_some_of_many (1.2.0)
-      activerecord (>= 7.0.0.alpha)
-      railties (>= 7.0.0.alpha)
     activestorage (8.0.2)
       actionpack (= 8.0.2)
       activejob (= 8.0.2)
@@ -590,7 +587,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  activerecord-has_some_of_many
   addressable (~> 2.8)
   axe-core-capybara (~> 4.9)
   axe-core-rspec (~> 4.8)

--- a/app/jobs/update_audit_job.rb
+++ b/app/jobs/update_audit_job.rb
@@ -1,8 +1,7 @@
 class UpdateAuditJob < ApplicationJob
   def perform(audit)
-    Audit.transaction do
-      audit.derive_status_from_checks
-      audit.set_checked_at
-    end
+    audit.derive_status_from_checks
+    audit.set_checked_at
+    audit.site.set_current_audit!
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -16,6 +16,7 @@ class Audit < ApplicationRecord
   scope :sort_by_url, -> { order(Arel.sql("REGEXP_REPLACE(audits.url, '^https?://(www\.)?', '') ASC")) }
   scope :checked, -> { where.not(status: :pending) }
   scope :to_schedule, -> { pending.joins(:checks).merge(Check.to_schedule) }
+  scope :current, -> { where(current: true) }
 
   Check.types.each do |name, klass|
     define_method(name) do

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,9 +2,8 @@ class Site < ApplicationRecord
   extend FriendlyId
 
   has_many :audits, dependent: :destroy
-  has_one_of_many :audit, -> { checked.sort_by_newest }, dependent: :destroy
 
-  scope :preloaded, -> { includes(:audit) }
+  scope :preloaded, -> {}
 
   friendly_id :url_without_scheme, use: [:slugged, :history]
 
@@ -23,7 +22,7 @@ class Site < ApplicationRecord
   end
 
   def url=(new_url)
-    audit = audits.build(url: new_url)
+    audits.build(url: new_url) unless url == new_url
   end
 
   def parsed_url = Link.parse(url)
@@ -31,7 +30,7 @@ class Site < ApplicationRecord
 
   def name = super.presence || url_without_scheme
   alias to_title name
-  def audit = super || audits.last || audits.build
+  def audit = audits.checked.last || audits.build
   def should_generate_new_friendly_id? = new_record? || (audit && slug != url_without_scheme.parameterize)
 
   def audit!

--- a/db/migrate/20250507132936_add_current_to_audits.rb
+++ b/db/migrate/20250507132936_add_current_to_audits.rb
@@ -1,0 +1,28 @@
+class AddCurrentToAudits < ActiveRecord::Migration[8.0]
+  def change
+    change_table :audits do |t|
+      t.boolean :current, null: false, default: false
+      t.index [:site_id, :current], unique: true, where: "current = true"
+    end
+
+    up_only do
+      say_with_time "set current = true for latest checked audits" do
+        execute <<~SQL.squish
+          WITH latest_audits AS (
+            SELECT id
+            FROM (
+              SELECT id, site_id,
+                     ROW_NUMBER() OVER (PARTITION BY site_id ORDER BY created_at DESC) as rn
+              FROM audits
+              WHERE status != 'pending'
+            ) ranked_audits
+            WHERE rn = 1
+          )
+          UPDATE audits
+          SET current = true
+          WHERE id IN (SELECT id FROM latest_audits)
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_06_075409) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_07_132936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,7 +21,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_06_075409) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "checked_at"
+    t.boolean "current", default: false, null: false
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
+    t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"
     t.index ["url"], name: "index_audits_on_url"
   end
@@ -61,9 +63,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_06_075409) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "audits_count", default: 0, null: false
+    t.bigint "audit_id"
+    t.index ["audit_id"], name: "index_sites_on_audit_id"
     t.index ["slug"], name: "index_sites_on_slug", unique: true
   end
 
   add_foreign_key "audits", "sites"
   add_foreign_key "checks", "audits"
+  add_foreign_key "sites", "audits"
 end

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :audit do
     url { "https://example.com" }
-    site { association :site, url: }
+    site { association :site, url:, audits: [instance] }
 
     trait :pending do
       status { "pending" }

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Audit do
   subject(:audit) { build(:audit, site: nil) }
 
-  let(:site) { create(:site) }
+  let(:site) { create(:site, audits: [audit]) }
 
   it "has a valid factory" do
     audit = build(:audit)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -8,12 +8,10 @@ RSpec.describe Site do
   end
 
   describe "delegations" do
-    let(:site) { create(:site) }
-    let!(:audit) { create(:audit, site:, url: "https://example.com") }
-
     it { should delegate_method(:url).to(:audit) }
 
     it "delegates to the most recent audit" do
+      site = create(:audit, url: "https://example.com").site
       new_audit = create(:audit, site:, url: "https://new-example.com")
       expect(site.reload.url).to eq(new_audit.url)
     end
@@ -33,7 +31,7 @@ RSpec.describe Site do
     end
 
     context "when a site exists for that URL" do
-      let!(:existing_site) { described_class.create(url:) }
+      let!(:existing_site) { create(:site, url:) }
 
       it "returns existing site" do
         expect(described_class.find_by_url(url:)).to eq(existing_site)
@@ -41,7 +39,7 @@ RSpec.describe Site do
     end
 
     context "when a site exists with a different scheme" do
-      let!(:existing_site) { described_class.create(url:) }
+      let!(:existing_site) { create(:site, url:) }
 
       it "returns existing site" do
         expect(described_class.find_by_url(url: url.sub("https:", "http:"))).to eq(existing_site)


### PR DESCRIPTION
- Remove has_some_of_many because the generated SQL breaks chaining
- Indicate current audit using a boolean, which simplifies preloading
- Update site.audit to return the current audit, or the latest, or build a new one