### PR TITLE
fix: Prevent duplicate audit jobs

### DIFF
--- a/app/jobs/run_audit_job.rb
+++ b/app/jobs/run_audit_job.rb
@@ -1,5 +1,6 @@
 class RunAuditJob < ApplicationJob
   def perform(audit)
+    audit.update!(scheduled: false)
     audit.all_checks.each { |check| check.schedule! }
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -20,7 +20,7 @@ Link = Data.define(:href, :text) do
     end
 
     def parse(href)
-      Addressable::URI.parse(href)
+      Addressable::URI.parse(href.to_s.strip)
     rescue Addressable::InvalidURIError
       raise InvalidURIError.new(href)
     end

--- a/db/migrate/20250527120328_add_scheduled_to_audits.rb
+++ b/db/migrate/20250527120328_add_scheduled_to_audits.rb
@@ -1,0 +1,5 @@
+class AddScheduledToAudits < ActiveRecord::Migration[8.0]
+  def change
+    add_column :audits, :scheduled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_26_082606) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_27_120328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_26_082606) do
     t.datetime "updated_at", null: false
     t.datetime "checked_at"
     t.boolean "current", default: false, null: false
+    t.boolean "scheduled", default: false
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
     t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"


### PR DESCRIPTION
Adding a site or requesting a new audit caused an unnecessary amount of UpdateAuditJob. This should no longer happen, lightening the load on the worker instance.