### PR TITLE
fix: Adjust component dom_id to accept an object

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -13,7 +13,13 @@ class ApplicationComponent < ViewComponent::Base
     end
   end
 
-  def dom_id(prefix: nil, suffix: nil)
-    [prefix, self.class.name.demodulize, object_id, suffix].compact.join("_").underscore
+  def dom_id(object = nil, prefix: nil, suffix: nil)
+    object ||= self # Default to the current component
+    klass, id = if object.is_a?(ApplicationRecord)
+      [object.model_name.param_key, object.to_param]
+    else
+      [object.class.name.gsub("::", "_"), object.object_id]
+    end
+    [prefix, klass, id, suffix].compact.join("_").underscore.gsub(/[^a-z0-9_]/i, "")
   end
 end

--- a/spec/components/application_component_spec.rb
+++ b/spec/components/application_component_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ApplicationComponent, type: :component do
+  let(:component) { described_class.new }
+
+  describe "#dom_id" do
+    context "when object is nil" do
+      it "uses the component's class and object_id" do
+        expect(component.dom_id).to eq("application_component_#{component.object_id}")
+      end
+    end
+
+    context "when object is a PORO" do
+      let(:object) { Object.new }
+
+      it "uses the object class name and object_id" do
+        expect(component.dom_id(object)).to eq("object_#{object.object_id}")
+      end
+    end
+
+    context "when object is an ApplicationRecord object" do
+      let(:record) { User.new(id: 123) }
+
+      it "uses the object's model_name and param" do
+        expect(component.dom_id(record)).to eq("user_123")
+      end
+    end
+
+    context "when object is namespaced" do
+      let(:namespaced_object) { Dsfr::PaginationComponent.new(pagy: double) }
+
+      it "replaces '::' with '_' in class name" do
+        expect(component.dom_id(namespaced_object)).to eq("dsfr_pagination_component_#{namespaced_object.object_id}")
+      end
+    end
+
+    context "when called with prefix and suffix options" do
+      let(:object) { Object.new }
+
+      it "includes prefix and suffix and removes invalid id characters" do
+        expect(component.dom_id(object, prefix: "PRE:FIX", suffix: "SU/FFIX")).to eq("prefix_object_#{object.object_id}_suffix")
+      end
+    end
+  end
+end


### PR DESCRIPTION
`dom_id` and `dom_class` don't work natively with view components:
```
dom_id(component) # => undefined method 'to_key' for an instance of [component]
dom_class(component) # => undefined method 'model_name' for an instance of [component]
```

But maybe adding `to_key` and `model_name` to ApplicationComponent and delegating to `super` would have been wiser?