### PR TITLE
refactor: Extract common Export code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ Organizational unit: Engineering
   utilisent [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
   Exemples de préfixes : `fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, etc.
 
+## Particularités
+
+### Helpers et raccourcis
+
+Pour améliorer l'expérience développeur, des raccourcis et des outils ont été mis en place
+
+- `human` : raccourci pour `human_attribute_name`. `User.human(:full_name)` : renvoie la traduction de la clé `full_name` pour la classe `User`. Accepte des options supplémentaires, comme la méthode originale. Il est également disponible au niveau des instances (`some_user.human(:foo)`).
+- `human_count` : raccourci pour compter des objets. Par défaut, compte le nombre d'éléments de la classe : `User.human_count` renvoie le nombre total d'utilisateurs. Il est possible d'indiquer un attribut et/ou un nombre : `User.human_count(:inactive, count: User.inactive.count)`.
+- `bulk_reset_counter(association, counter: nil)` fait ce qu'on attend de `reset_counters` : prendre un nom d'association, le nom du compteur s'il diffère du nom par défaut, et met à jour toute la table en une seule requête SQL. TODO : proposer de l'upstreamer dans Rails.
+- `page_title` : récupère ou génère le titre de page. Cherche successivement dans `@title`, `content_for(:title)`, la méthode `to_title` de la ressource courante si on est dans une action de type `:show`, ou dans la configuration I18n du contrôleur courant.
+- `head_title` : concatène le titre de page et le nom du site, et l'insère dans le layout principal.
+- `time_ago` : affiche "il y a X minutes/heures/jours…" ou "dans X minutes/heures/jours…". Bien plus court à taper que `distance_of_time_in_words_to_now`.
+- `page_actions` permet de regrouper les boutons et actions, avec les même styles d'une page à l'autre.
+
+### Extensions ActiveRecord
+
+- `order_by` et `filter_by`. Ces méthodes sont injectées dans `ActiveRecord`, et gérées dans `app/queries/[model]_query.rb`. Grâce à cela, il est possible d'appeler `User.preloaded.filter_by(params[:filter]).order_by(params[:sort])` pour filtrer et trier les résultats.
+- `to_csv` et `to_csv_filename` sont injectées dans `ActiveRecord`, pour permettre d'exporter une requête en CSV avec un minimum de configuration.
+
+### Composants
+
+Les composants DSFR qui ne sont pas encore implémentés dans dsfr-view-components sont implémentés dans le dossier
+`app/components/dsfr/`. Des helpers sont également inclus pour les appeler avec une syntaxe concise et des valeurs par défaut logiques.
+
 ## 🧪 Tests
 
 ### Docker setup

--- a/app/export/application_export.rb
+++ b/app/export/application_export.rb
@@ -9,7 +9,24 @@ class ApplicationExport
     @relation = relation
   end
 
-  def extension = self.class::EXTENSION
+  def extension
+    self.class::EXTENSION
+  rescue NameError
+    raise NotImplementedError, "#{self.class} must define EXTENSION constant"
+  end
+
+  def attributes
+    raise NotImplementedError, "#{self.class} must implement #attributes method"
+  end
+
   def filename = "#{table_name}_#{l Time.zone.now, format: :file}.#{extension}"
   def records = relation.find_each
+  def headers = attributes.keys
+
+  def serialize(record)
+    attributes.values.map do |methods|
+      # Turns [:a, :b, :c] into record.a&.b&.c
+      Array.wrap(methods).reduce(record) { |obj, method| obj&.public_send(method) }
+    end
+  end
 end

--- a/app/export/csv_export.rb
+++ b/app/export/csv_export.rb
@@ -1,0 +1,16 @@
+class CsvExport < ApplicationExport
+  EXTENSION = "csv"
+
+  def csv_options
+    { col_sep: ";" }
+  end
+
+  def to_csv
+    CSV.generate(**csv_options.merge(headers: true)) do |csv|
+      csv << headers
+      records.each do |record|
+        csv << serialize(record)
+      end
+    end
+  end
+end

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -1,15 +1,4 @@
-class SiteCsvExport < ApplicationExport
-  EXTENSION = "csv"
-
-  def to_csv
-    CSV.generate(headers: true, col_sep: ";") do |csv|
-      csv << attributes.keys
-      records.each do |record|
-        csv << serialize(record)
-      end
-    end
-  end
-
+class SiteCsvExport < CsvExport
   def attributes
     {
       human(:url) => :url,
@@ -23,14 +12,5 @@ class SiteCsvExport < ApplicationExport
       Checks::AnalyzeAccessibilityPage.human(:audit_update_date) => [:audit, :analyze_accessibility_page, :audit_update_date],
       Checks::RunAxeOnHomepage.human(:success_rate) => [:audit, :run_axe_on_homepage, :human_success_rate],
     }
-  end
-
-  def headers = attributes.keys
-
-  def serialize(record)
-    attributes.values.map do |methods|
-      # Turns [:a, :b, :c] into record.a&.b&.c
-      Array.wrap(methods).reduce(record) { |obj, method| obj&.public_send(method) }
-    end
   end
 end

--- a/spec/export/application_export_spec.rb
+++ b/spec/export/application_export_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe ApplicationExport, type: :model do
+  let(:relation) { Site.all }
+  let(:concrete_export_class) do
+    Class.new(ApplicationExport) do
+      const_set(:EXTENSION, "test")
+
+      def attributes
+        {
+          "Name" => :name,
+          "URL" => :url,
+          "Nested" => [:audit, :checked_at]
+        }
+      end
+    end
+  end
+  let(:concrete_export) { concrete_export_class.new(relation) }
+  let(:export) { concrete_export }
+
+  describe "#initialize" do
+    it "sets the relation" do
+      expect(export.instance_variable_get(:@relation)).to eq(relation)
+    end
+  end
+
+  describe "#extension" do
+    it "returns the class EXTENSION constant" do
+      expect(export.extension).to eq("test")
+    end
+
+    it "raises NotImplementedError when EXTENSION is not defined" do
+      export_without_extension = Class.new(described_class).new(relation)
+      expect { export_without_extension.extension }.to raise_error(NotImplementedError, /must define EXTENSION constant/)
+    end
+  end
+
+  describe "#filename" do
+    it "generates filename with table name and timestamp" do
+      allow(I18n).to receive(:l).and_return("20240101_120000")
+      expect(export.filename).to eq("sites_20240101_120000.test")
+    end
+  end
+
+  describe "#records" do
+    it "returns find_each enumerable" do
+      expect(export.records).to respond_to(:each)
+    end
+  end
+
+  describe "#attributes" do
+    it "raises NotImplementedError for base class" do
+      base_export = described_class.new(relation)
+      expect { base_export.attributes }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#serialize" do
+    let(:site) { build(:site, url: "https://test.com") }
+    let(:audit) { build(:audit, checked_at: Time.zone.parse("2024-01-01 12:00:00")) }
+
+    before do
+      allow(site).to receive(:audit).and_return(audit)
+    end
+
+    it "serializes simple attributes" do
+      allow(site).to receive_messages(name: "Test Site", url: "https://test.com")
+      result = export.serialize(site)
+      expect(result[0]).to eq("Test Site")
+      expect(result[1]).to eq("https://test.com")
+    end
+
+    it "serializes nested attributes" do
+      result = export.serialize(site)
+      expect(result[2]).to eq(Time.zone.parse("2024-01-01 12:00:00"))
+    end
+
+    it "handles nil values in chain" do
+      allow(site).to receive_messages(name: "Test Site", url: "https://test.com", audit: nil)
+      result = export.serialize(site)
+      expect(result[2]).to be_nil
+    end
+  end
+end

--- a/spec/export/csv_export_spec.rb
+++ b/spec/export/csv_export_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CsvExport, type: :model do
+RSpec.describe CsvExport do
   let(:relation) { Site.all }
   let(:concrete_export_class) do
     Class.new(CsvExport) do
@@ -43,34 +43,24 @@ RSpec.describe CsvExport, type: :model do
   end
 
   describe "#to_csv" do
-    let(:site1) { build(:site, url: "https://site1.com") }
-    let(:site2) { build(:site, url: "https://site2.com") }
+    let(:site1) { build(:site, name: "Site 1", url: "https://site1.com") }
+    let(:site2) { build(:site, name: "Site 2", url: "https://site2.com") }
+    let(:lines) { export.to_csv.split("\n") }
 
     before do
-      allow(site1).to receive_messages(name: "Site 1", url: "https://site1.com")
-      allow(site2).to receive_messages(name: "Site 2", url: "https://site2.com")
       allow(export).to receive(:records).and_return([site1, site2])
     end
 
     it "generates CSV with headers" do
-      csv_output = export.to_csv
-      lines = csv_output.split("\n")
-
       expect(lines.first).to eq("Name;URL")
     end
 
     it "generates CSV with semicolon separator" do
-      csv_output = export.to_csv
-      lines = csv_output.split("\n")
-
       expect(lines[1]).to include("Site 1;https://site1.com")
       expect(lines[2]).to include("Site 2;https://site2.com")
     end
 
     it "includes all records" do
-      csv_output = export.to_csv
-      lines = csv_output.split("\n")
-
       expect(lines.length).to eq(3) # header + 2 records
     end
   end

--- a/spec/export/csv_export_spec.rb
+++ b/spec/export/csv_export_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe CsvExport, type: :model do
+  let(:relation) { Site.all }
+  let(:concrete_export_class) do
+    Class.new(CsvExport) do
+      def attributes
+        {
+          "Name" => :name,
+          "URL" => :url
+        }
+      end
+    end
+  end
+  let(:export) { concrete_export_class.new(relation) }
+
+  describe "EXTENSION" do
+    it "is set to csv" do
+      expect(CsvExport::EXTENSION).to eq("csv")
+    end
+  end
+
+  describe "#headers" do
+    it "returns attribute keys" do
+      expect(export.headers).to eq(["Name", "URL"])
+    end
+  end
+
+  describe "#csv_options" do
+    it "returns default CSV options" do
+      expect(export.csv_options).to eq({ col_sep: ";" })
+    end
+
+    it "can be overridden in subclasses" do
+      custom_export_class = Class.new(CsvExport) do
+        def csv_options
+          { col_sep: ",", quote_char: "'" }
+        end
+      end
+      custom_export = custom_export_class.new(relation)
+      expect(custom_export.csv_options).to eq({ col_sep: ",", quote_char: "'" })
+    end
+  end
+
+  describe "#to_csv" do
+    let(:site1) { build(:site, url: "https://site1.com") }
+    let(:site2) { build(:site, url: "https://site2.com") }
+
+    before do
+      allow(site1).to receive_messages(name: "Site 1", url: "https://site1.com")
+      allow(site2).to receive_messages(name: "Site 2", url: "https://site2.com")
+      allow(export).to receive(:records).and_return([site1, site2])
+    end
+
+    it "generates CSV with headers" do
+      csv_output = export.to_csv
+      lines = csv_output.split("\n")
+
+      expect(lines.first).to eq("Name;URL")
+    end
+
+    it "generates CSV with semicolon separator" do
+      csv_output = export.to_csv
+      lines = csv_output.split("\n")
+
+      expect(lines[1]).to include("Site 1;https://site1.com")
+      expect(lines[2]).to include("Site 2;https://site2.com")
+    end
+
+    it "includes all records" do
+      csv_output = export.to_csv
+      lines = csv_output.split("\n")
+
+      expect(lines.length).to eq(3) # header + 2 records
+    end
+  end
+end


### PR DESCRIPTION
- [x] SiteCsvExport < CsvExport < ApplicationExport
- [x] `serialize` is now in base class
- [x] CsvExport handles all CSV-related conversion
- [x] CSV options can be overridden by subclasses
- [x] Errors are raised if subclasses don't implement `attributes` and have an `EXTENSION` constant.