### PR TITLE
chore: allow nil names for user in DB

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
     ]).from("inactive_users")
   end
 
-  validates :provider, :uid, :email, :given_name, :usual_name, :siret, presence: true
+  validates :provider, :uid, :email, :siret, presence: true
+  validate :name_presence_validation
   validates :uid, uniqueness: { scope: :provider, if: :uid_changed? }
   validates :email, uniqueness: { scope: :provider, if: :email_changed? }
   validates :email, email: true
@@ -45,11 +46,15 @@ class User < ApplicationRecord
   end
 
   def full_name
-    "#{given_name} #{usual_name}"
+    [given_name, usual_name].compact.join(" ")
   end
   alias to_title full_name
 
   private
+
+  def name_presence_validation
+    errors.add(:base, "Either given_name or usual_name must be present") if given_name.blank? && usual_name.blank?
+  end
 
   def find_or_create_team
     self.team ||= Team.find_or_create_by(siret:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,12 +48,13 @@ class User < ApplicationRecord
   def full_name
     [given_name, usual_name].compact.join(" ")
   end
+
   alias to_title full_name
 
   private
 
   def name_presence_validation
-    errors.add(:base, "Either given_name or usual_name must be present") if given_name.blank? && usual_name.blank?
+    errors.add(:given_name, :blank) if given_name.blank? && usual_name.blank?
   end
 
   def find_or_create_team

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -45,11 +45,6 @@ fr:
     formats:
       compact: "%Y/%m/%d"
 
-  errors:
-    attributes:
-      url:
-        invalid: invalide
-
   activemodel:
     errors:
       models:
@@ -241,10 +236,21 @@ fr:
         email: Adresse électronique
 
   errors:
+    attributes:
+      url:
+        invalid: invalide
+      given_name:
+        blank: Veuillez indiquer au moins un prénom ou un nom.
     not_found:
       title: "Page non trouvée (erreur 404)"
     internal_server_error:
       title: "Problème technique (erreur 500)"
+  #    models:
+  #      user:
+  #        attributes:
+  #          given_name:
+  #            blank: Veuillez indiquer au moins un prénom ou un nom.
+
   pages:
     accessibilite:
       title: Déclaration d’accessibilité

--- a/db/migrate/20250730150831_allow_nullable_names_for_users.rb
+++ b/db/migrate/20250730150831_allow_nullable_names_for_users.rb
@@ -1,0 +1,6 @@
+class AllowNullableNamesForUsers < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :users, :given_name, true
+    change_column_null :users, :usual_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_04_152906) do
     t.datetime "updated_at", null: false
     t.datetime "checked_at"
     t.boolean "current", default: false, null: false
+    t.boolean "scheduled", default: false, null: false
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
     t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"
@@ -46,7 +47,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_04_152906) do
     t.string "error_backtrace", default: [], array: true
     t.datetime "retry_at"
     t.integer "retry_count", default: 0, null: false
-    t.datetime "run_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "run_at"
     t.index ["audit_id"], name: "index_checks_on_audit_id"
     t.index ["status", "run_at"], name: "index_checks_on_status_and_run_at"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe User do
         user.given_name = nil
         user.usual_name = nil
         expect(user).not_to be_valid
-        expect(user.errors[:base]).to include("Either given_name or usual_name must be present")
+        expect(user.errors[:given_name]).to include("Veuillez indiquer au moins un prénom ou un nom.")
       end
 
       it "is valid with only given_name" do


### PR DESCRIPTION
### Model
* Removed the requirement for `given_name` and `usual_name` to always be present in the `User` model and added a custom validation to ensure at least one of these fields is provided. 
* Updated the `full_name` method 

### Database 
* Added a migration to allow `given_name` and `usual_name` to be nullable in the database. 