### PR TITLE
refactor: Edit retryable errors

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -14,6 +14,7 @@ class Check < ApplicationRecord
   MAX_RETRIES = 3
   RETRYABLE_ERRORS = [
     "Errno::ECONNREFUSED",
+    "NoMethodError", # raised when Ferrum is restarted while a check is running
     "Ferrum::PendingConnectionsError",
     "Ferrum::ProcessTimeoutError",
     "Ferrum::StatusError",

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -66,8 +66,6 @@ class Check < ApplicationRecord
   def tooltip? = true
 
   def calculate_retry_at
-    return nil unless retryable?
-
     (5 * (5 ** retry_count)).minutes.from_now # Exponential backoff: 5min, 25min, 125min (2h5m)
   end
 
@@ -120,7 +118,7 @@ class Check < ApplicationRecord
       status: :failed,
       checked_at: Time.zone.now,
       retry_count: retry_count + 1,
-      retry_at: retryable? ? calculate_retry_at : nil
+      retry_at: calculate_retry_at
     )
     report(exception:) do |scope|
       scope.set_context("check", { id:, type:, retry_count: })

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -13,10 +13,12 @@ class Check < ApplicationRecord
   REQUIREMENTS = [:reachable]
   MAX_RETRIES = 3
   RETRYABLE_ERRORS = [
+    "Errno::ECONNREFUSED",
     "Ferrum::PendingConnectionsError",
     "Ferrum::ProcessTimeoutError",
     "Ferrum::StatusError",
     "Ferrum::TimeoutError",
+    "ThreadError",
   ].freeze
 
   belongs_to :audit

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -54,7 +54,7 @@ class Check < ApplicationRecord
   def requirements = self.class::REQUIREMENTS # Returns subclass constant value, defaults to parent class
   def waiting? = requirements&.any? { audit.check_status(it).pending? } || false
   def blocked? = requirements&.any? { audit.check_status(it).failed? || audit.check_status(it).blocked? } || false
-  def retryable? = retry_count < MAX_RETRIES && (error_type.nil? || error_type.start_with?("Ferrum"))
+  def retryable? = failed? && retry_count < MAX_RETRIES && (error_type.nil? || error_type.start_with?("Ferrum"))
   def tooltip? = true
 
   def calculate_retry_at

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -9,9 +9,9 @@ class Check < ApplicationRecord
     :run_axe_on_homepage,
   ].freeze
 
-  MAX_RETRIES = 3
   PRIORITY = 100 # Override in subclasses if necessary, lower numbers run first
   REQUIREMENTS = [:reachable]
+  MAX_RETRIES = 3
 
   belongs_to :audit
   has_one :site, through: :audit


### PR DESCRIPTION
I've retried some non-Ferrum errors which were retryable after all. I've therefore listed retryable errors explicitly, which is more readable anyway.