### PR TITLE
fix: Update user team when a user connects through ProConnect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,7 +57,7 @@ RSpec/MultipleMemoizedHelpers:
   AllowSubject: true
   Max: 10
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 RSpec/ContextWording:
   Prefixes:
     - and

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
         given_name: data_source.given_name,
         usual_name: data_source.usual_name
       )
-      user.team ||= Team.find_or_initialize_by(siret:)
+      user.team ||= Team.find_or_initialize_by(siret:) unless user.siret == user.team&.siret
       user.team.save if user.valid?
       return unless user.save
 


### PR DESCRIPTION
Otherwise when an existing user arrives with a different SIRET, the team would remain the same until reconnection.