### PR TITLE
fix: duplicate call to audit schedule & set current audit

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -9,7 +9,7 @@ class SitesController < ApplicationController
     sites = current_user.sites.preloaded.filter_by(params).order_by(params)
     respond_to do |format|
       format.html { @pagy, @sites = pagy sites, limit: pagy_limit }
-      format.csv  { send_data sites.to_csv, filename: sites.to_csv_filename }
+      format.csv { send_data sites.to_csv, filename: sites.to_csv_filename }
     end
   end
 
@@ -31,7 +31,6 @@ class SitesController < ApplicationController
     @site.assign_attributes(site_params)
     notice = t(@site.new_record? ? ".created" : ".new_audit")
     if @site.save
-      @site.audit.schedule if @site.audit.pending?
       redirect_to @site, notice:
     else
       render :new, status: :unprocessable_content
@@ -42,7 +41,6 @@ class SitesController < ApplicationController
   def upload
     @upload = SiteUpload.new(site_upload_params)
     if @upload.save
-      ScheduleAuditsJob.perform_later
       redirect_to sites_path, notice: t(".uploaded", count: @upload.count)
     else
       render :new, status: :unprocessable_content

--- a/app/jobs/schedule_audits_job.rb
+++ b/app/jobs/schedule_audits_job.rb
@@ -1,7 +1,0 @@
-class ScheduleAuditsJob < ApplicationJob
-  def perform
-    Audit.pending.find_each do |audit|
-      audit.schedule
-    end
-  end
-end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -10,7 +10,7 @@ class Site < ApplicationRecord
   scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
   scope :preloaded, -> { with_current_audit.includes(:tags, audits: :checks) }
 
-  after_save :set_current_audit!, unless: -> { audits_count == (audits_count_before_last_save || 0) }
+  after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
 
   friendly_id :url_without_scheme, use: [:slugged, :history, :scoped], scope: :team_id
 
@@ -46,7 +46,6 @@ class Site < ApplicationRecord
   end
 
   def name = super.presence || url_without_scheme
-
   alias to_title name
   alias to_s name
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -10,7 +10,7 @@ class Site < ApplicationRecord
   scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
   scope :preloaded, -> { with_current_audit.includes(:tags, audits: :checks) }
 
-  after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
+  after_save :set_current_audit!, unless: -> { audits_count == (audits_count_before_last_save || 0) }
 
   friendly_id :url_without_scheme, use: [:slugged, :history, :scoped], scope: :team_id
 
@@ -46,6 +46,7 @@ class Site < ApplicationRecord
   end
 
   def name = super.presence || url_without_scheme
+
   alias to_title name
   alias to_s name
 
@@ -56,6 +57,7 @@ class Site < ApplicationRecord
   end
 
   def should_generate_new_friendly_id? = new_record? || (slug != url_without_scheme.parameterize) || super
+
   def update_slug! = tap { self.slug = nil; friendly_id }.save!
 
   def audit

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Sites" do
 
     it "creates a site and schedules checks automatically" do
       expect { post_site }.to change(Site, :count).by(1)
-       .and change(Audit, :count).by(1)
-       .and change(Check, :count).by(Check.names.count)
+                                                  .and change(Audit, :count).by(1)
+                                                                            .and change(Check, :count).by(Check.names.count)
 
       site = Site.last
       audit = site.audit
@@ -57,7 +57,7 @@ RSpec.describe "Sites" do
       upload_mock = instance_double(SiteUpload, save: true, count: 2)
       allow(SiteUpload).to receive(:new).and_return(upload_mock)
 
-      expect { upload_sites }.to have_enqueued_job(ScheduleAuditsJob)
+      upload_sites
 
       expect(response).to redirect_to(sites_path)
       follow_redirect!

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Sites" do
 
     it "creates a site and schedules checks automatically" do
       expect { post_site }.to change(Site, :count).by(1)
-                                                  .and change(Audit, :count).by(1)
-                                                                            .and change(Check, :count).by(Check.names.count)
+        .and change(Audit, :count).by(1)
+        .and change(Check, :count).by(Check.names.count)
 
       site = Site.last
       audit = site.audit


### PR DESCRIPTION
**Audit Scheduling Logic Removal:**

* Removed the call to `@site.audit.schedule` when creating a new site in `SitesController#create`
* Removed the call to `ScheduleAuditsJob.perform_later` in `SitesController#upload`

**Model Logic Updates:**

* Updated the `Site` model's `after_save` callback to correctly handle cases when `audits_count_before_last_save` is `nil`