### PR TITLE
refactor: Split audit and check jobs

### DIFF
--- a/app/jobs/process_audit_job.rb
+++ b/app/jobs/process_audit_job.rb
@@ -1,38 +1,9 @@
 class ProcessAuditJob < ApplicationJob
   limits_concurrency to: 1, key: ->(audit) { audit }
 
-  attr_reader :audit
-  delegate :checks, to: :audit
-
   def perform(audit)
-    @audit = audit
-
-    if (check = next_check)
-      check.run
-      audit.derive_status_from_checks
-      reschedule
-    else
-      audit.finalize!
+    if (check = audit.next_check)
+      RunCheckJob.perform_later(check)
     end
-  end
-
-  private
-
-  def next_check
-    checks.pending.first ||
-    checks.to_retry.first ||
-    unblocked_checks.first
-  end
-
-  def unblocked_checks
-    checks.blocked.reject(&:blocked?)
-  end
-
-  def reschedule
-    next_retry_at = checks.failed.retryable.minimum(:retry_at)
-    next_run_at = checks.pending.minimum(:run_at)
-
-    wait_until = [next_retry_at, next_run_at].compact.min || 1.minute.from_now
-    self.class.set(wait_until:, group: "audit_#{audit.id}").perform_later(audit)
   end
 end

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,0 +1,25 @@
+class RunCheckJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(check) { check.audit_id }
+
+  attr_reader :check
+  delegate :audit, to: :check
+  delegate :checks, to: :audit, prefix: true
+
+  def perform(check)
+    @check = check
+    check.run
+    audit.update_from_checks
+
+    if (next_schedulable_check = audit.next_check)
+      self.class.set(wait_until:).perform_later(next_schedulable_check)
+    end
+  end
+
+  private
+
+  def wait_until
+    next_retry_at = audit_checks.failed.retryable.minimum(:retry_at)
+    next_run_at = audit_checks.pending.minimum(:run_at)
+    [next_retry_at, next_run_at].compact.min || 1.second.from_now
+  end
+end

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,6 +1,4 @@
 class RunCheckJob < ApplicationJob
-  limits_concurrency to: 1, key: ->(check) { check.audit_id }
-
   attr_reader :check
   delegate :audit, to: :check
   delegate :checks, to: :audit, prefix: true

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,23 +1,13 @@
 class RunCheckJob < ApplicationJob
-  attr_reader :check
-  delegate :audit, to: :check
-  delegate :checks, to: :audit, prefix: true
-
   def perform(check)
-    @check = check
+    audit = check.audit
+
     check.run
     audit.update_from_checks
 
-    if (next_schedulable_check = audit.next_check)
-      self.class.set(wait_until:).perform_later(next_schedulable_check)
+    if (next_check = audit.next_check)
+      wait_until = next_check.retry_at || next_check.run_at || 1.second.from_now
+      self.class.set(wait_until:).perform_later(next_check)
     end
-  end
-
-  private
-
-  def wait_until
-    next_retry_at = audit_checks.failed.retryable.minimum(:retry_at)
-    next_run_at = audit_checks.pending.minimum(:run_at)
-    [next_retry_at, next_run_at].compact.min || 1.second.from_now
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -40,23 +40,22 @@ class Audit < ApplicationRecord
     all_checks.select(&:new_record?).each(&:save)
   end
 
-  def derive_status_from_checks
-    self.status = if all_checks.any?(&:new_record?)
+  def status_from_checks
+    if all_checks.any?(&:new_record?)
        :pending
     elsif (check_statuses = checks.collect(&:status).uniq).one?
-       check_statuses.first
+       check_statuses.first.to_sym
     else
        :mixed
     end
-    update(status:)
   end
 
-  def finalize!
+  def latest_checked_at = checks.collect(&:checked_at).compact.sort.last
+
+  def update_from_checks
     transaction do
-      derive_status_from_checks
-      latest_checked_at = checks.collect(&:checked_at).compact.sort.last
-      update(checked_at: latest_checked_at)
-      site.set_current_audit!
+      update(status: status_from_checks, checked_at: latest_checked_at)
+      site.set_current_audit! unless pending?
     end
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -40,6 +40,12 @@ class Audit < ApplicationRecord
     all_checks.select(&:new_record?).each(&:save)
   end
 
+  def next_check
+    checks.pending.first ||
+    checks.to_retry.first ||
+    checks.blocked.reject(&:blocked?).first
+  end
+
   def status_from_checks
     if all_checks.any?(&:new_record?)
        :pending

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RunCheckJob do
   let(:retryable_error) { Check::RETRYABLE_ERRORS.first }
 
   describe '#perform' do
-    it 'runs the given check' do
+    it 'runs check and updates audit', :aggregate_failures do
       allow(check).to receive(:run)
       allow(audit).to receive(:update_from_checks)
       allow(audit).to receive(:next_check).and_return(nil)
@@ -15,15 +15,6 @@ RSpec.describe RunCheckJob do
       described_class.new.perform(check)
 
       expect(check).to have_received(:run)
-    end
-
-    it 'updates audit status after running check' do
-      allow(check).to receive(:run)
-      allow(audit).to receive(:update_from_checks)
-      allow(audit).to receive(:next_check).and_return(nil)
-
-      described_class.new.perform(check)
-
       expect(audit).to have_received(:update_from_checks)
     end
 
@@ -42,55 +33,6 @@ RSpec.describe RunCheckJob do
         job.perform(check)
 
         expect(job_class_double).to have_received(:perform_later).with(next_check)
-      end
-    end
-
-    context 'when no more checks remain' do
-      it 'does not reschedule' do
-        job = described_class.new
-        allow(check).to receive(:run)
-        allow(audit).to receive(:update_from_checks)
-        allow(audit).to receive(:next_check).and_return(nil)
-
-        allow(described_class).to receive(:set)
-
-        job.perform(check)
-
-        expect(described_class).not_to have_received(:set)
-      end
-    end
-  end
-
-  describe '#wait_until' do
-    let(:job) { described_class.new }
-
-    before { job.instance_variable_set(:@check, check) }
-
-    context 'when there are failed retryable checks' do
-      it 'returns earliest retry time' do
-        audit.checks.first.update!(status: :failed, retry_at: 1.minute.from_now, error_type: retryable_error)
-        audit.checks.where.not(id: audit.checks.first.id).update_all(status: :passed)
-        retry_at = audit.checks.first.reload.retry_at
-
-        expect(job.send(:wait_until)).to eq(retry_at)
-      end
-    end
-
-    context 'when there are pending checks with run_at' do
-      it 'returns earliest run_at time' do
-        run_at = 30.minutes.from_now
-        audit.checks.first.update!(status: :pending, run_at: run_at)
-        audit.checks.where.not(id: audit.checks.first.id).update_all(status: :passed)
-
-        expect(job.send(:wait_until)).to be_within(1.second).of(run_at)
-      end
-    end
-
-    context 'when there are no scheduled checks' do
-      it 'returns 1 second from now' do
-        audit.checks.update_all(status: :passed)
-
-        expect(job.send(:wait_until)).to be_within(1.second).of(1.second.from_now)
       end
     end
   end

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe RunCheckJob do
+  let(:site) { create(:site) }
+  let(:audit) { create(:audit, site: site) }
+  let(:check) { audit.checks.first }
+  let(:retryable_error) { Check::RETRYABLE_ERRORS.first }
+
+  describe '#perform' do
+    it 'runs the given check' do
+      allow(check).to receive(:run)
+      allow(audit).to receive(:update_from_checks)
+      allow(audit).to receive(:next_check).and_return(nil)
+
+      described_class.new.perform(check)
+
+      expect(check).to have_received(:run)
+    end
+
+    it 'updates audit status after running check' do
+      allow(check).to receive(:run)
+      allow(audit).to receive(:update_from_checks)
+      allow(audit).to receive(:next_check).and_return(nil)
+
+      described_class.new.perform(check)
+
+      expect(audit).to have_received(:update_from_checks)
+    end
+
+    context 'when more checks remain' do
+      it 'reschedules itself with the next check' do
+        next_check = audit.checks.last
+        job = described_class.new
+        allow(check).to receive(:run)
+        allow(audit).to receive(:update_from_checks)
+        allow(audit).to receive(:next_check).and_return(next_check)
+
+        job_class_double = class_double(described_class)
+        allow(described_class).to receive(:set).with(wait_until: kind_of(Time)).and_return(job_class_double)
+        allow(job_class_double).to receive(:perform_later)
+
+        job.perform(check)
+
+        expect(job_class_double).to have_received(:perform_later).with(next_check)
+      end
+    end
+
+    context 'when no more checks remain' do
+      it 'does not reschedule' do
+        job = described_class.new
+        allow(check).to receive(:run)
+        allow(audit).to receive(:update_from_checks)
+        allow(audit).to receive(:next_check).and_return(nil)
+
+        allow(described_class).to receive(:set)
+
+        job.perform(check)
+
+        expect(described_class).not_to have_received(:set)
+      end
+    end
+  end
+
+  describe '#wait_until' do
+    let(:job) { described_class.new }
+
+    before { job.instance_variable_set(:@check, check) }
+
+    context 'when there are failed retryable checks' do
+      it 'returns earliest retry time' do
+        audit.checks.first.update!(status: :failed, retry_at: 1.minute.from_now, error_type: retryable_error)
+        audit.checks.where.not(id: audit.checks.first.id).update_all(status: :passed)
+        retry_at = audit.checks.first.reload.retry_at
+
+        expect(job.send(:wait_until)).to eq(retry_at)
+      end
+    end
+
+    context 'when there are pending checks with run_at' do
+      it 'returns earliest run_at time' do
+        run_at = 30.minutes.from_now
+        audit.checks.first.update!(status: :pending, run_at: run_at)
+        audit.checks.where.not(id: audit.checks.first.id).update_all(status: :passed)
+
+        expect(job.send(:wait_until)).to be_within(1.second).of(run_at)
+      end
+    end
+
+    context 'when there are no scheduled checks' do
+      it 'returns 1 second from now' do
+        audit.checks.update_all(status: :passed)
+
+        expect(job.send(:wait_until)).to be_within(1.second).of(1.second.from_now)
+      end
+    end
+  end
+end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -73,26 +73,76 @@ RSpec.describe Audit do
     end
   end
 
-  describe "#derive_status_from_checks" do
-    let(:audit) { build(:audit) }
+  describe "#status_from_checks" do
+    context "with new checks" do
+      let(:audit) { build(:audit) }
 
-    it "sets status to pending when any check is new" do
-      audit = build(:audit)
-      audit.derive_status_from_checks
-      expect(audit.status).to eq("pending")
+      it "returns pending when any check is new" do
+        expect(audit.status_from_checks).to eq(:pending)
+      end
     end
 
-    it "sets status to mixed when checks have different statuses" do
-      audit.all_checks.each { |check| check.passed!; check.save }
-      audit.checks.last.update!(status: :failed)
-      audit.derive_status_from_checks
+    context "with existing checks of different statuses" do
+      let(:audit) { create(:audit) }
+
+      before do
+        audit.all_checks.each { |check| check.passed!; check.save }
+        audit.checks.last.update!(status: :failed)
+      end
+
+      it "returns mixed when checks have different statuses" do
+        expect(audit.status_from_checks).to eq(:mixed)
+      end
+    end
+
+    context "with existing checks of same status" do
+      let(:audit) { create(:audit) }
+
+      before do
+        audit.all_checks.each { |check| check.update(status: :passed) }
+      end
+
+      it "returns the unified status when all checks have same status" do
+        expect(audit.status_from_checks).to eq(:passed)
+      end
+    end
+  end
+
+  describe "#update_from_checks" do
+    let(:audit) { create(:audit) }
+
+    it "updates status using status_from_checks" do
+      allow(audit).to receive_messages(status_from_checks: :mixed, latest_checked_at: 1.hour.ago)
+
+      audit.update_from_checks
       expect(audit.status).to eq("mixed")
     end
 
-    it "sets status to match checks when all have same status" do
-      audit.all_checks.each { |check| check.update(status: :passed) }
-      audit.derive_status_from_checks
-      expect(audit.status).to eq("passed")
+    it "updates checked_at using latest_checked_at" do
+      checked_at = 1.hour.ago
+      allow(audit).to receive_messages(status_from_checks: :passed, latest_checked_at: checked_at)
+
+      audit.update_from_checks
+      expect(audit.checked_at).to be_within(1.second).of(checked_at)
+    end
+
+    it "calls set_current_audit! on site when not pending" do
+      allow(audit).to receive_messages(status_from_checks: :passed, latest_checked_at: 1.hour.ago)
+
+      expect(audit.site).to receive(:set_current_audit!)
+      audit.update_from_checks
+    end
+
+    it "does not call set_current_audit! on site when pending" do
+      allow(audit).to receive_messages(status_from_checks: :pending, latest_checked_at: nil)
+
+      expect(audit.site).not_to receive(:set_current_audit!)
+      audit.update_from_checks
+    end
+
+    it "runs in a transaction" do
+      expect(audit).to receive(:transaction).and_yield
+      audit.update_from_checks
     end
   end
 
@@ -117,30 +167,6 @@ RSpec.describe Audit do
     it "calls create_checks when audit is created" do
       expect(audit).to receive(:create_checks).and_call_original
       expect { audit.save! }.to change(Check, :count).by(Check.types.size)
-    end
-  end
-
-  describe "#finalize!" do
-    let(:audit) { create(:audit) }
-    let!(:check1) { audit.checks.first.tap { |c| c.update!(status: :passed, checked_at: 2.hours.ago) } }
-    let!(:check2) { audit.checks.second.tap { |c| c.update!(status: :failed, checked_at: 1.hour.ago) } }
-
-    it "derives status from checks" do
-      expect { audit.finalize! }.to change(audit, :status).to("mixed")
-    end
-
-    it "sets checked_at to latest check's checked_at" do
-      expect { audit.finalize! }.to change(audit, :checked_at).to(check2.checked_at)
-    end
-
-    it "calls set_current_audit! on site" do
-      expect(audit.site).to receive(:set_current_audit!)
-      audit.finalize!
-    end
-
-    it "runs in a transaction" do
-      expect(audit).to receive(:transaction).and_yield
-      audit.finalize!
     end
   end
 


### PR DESCRIPTION
À la demande générale de @freesteph, et pour que ce soit plus clair quand on étudie les logs des jobs, cette PR crée un job spécifique pour les checks.