### PR TITLE
RFC: introduce a state machine for Checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem "omniauth-rails_csrf_protection"
 gem "ferrum"
 gem "brotli"
 gem "zstd-ruby"
+gem "statesman"
 
 group :development, :test do
   gem "debug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,6 +594,7 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    statesman (12.1.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
@@ -707,6 +708,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  statesman
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -3,7 +3,7 @@ class SiteCsvExport < CsvExport
     {
       human(:url) => :url,
       Check.human(:checked_at) => [:audit, :checked_at],
-      Checks::Reachable.human(:type) => [:audit, :reachable, :passed?],
+      Checks::Reachable.human(:type) => [:audit, :reachable, :completed?],
       Checks::LanguageIndication.human(:type) => [:audit, :language_indication, :indication],
       Checks::AccessibilityMention.human(:type) => [:audit, :accessibility_mention, :mention_text],
       Checks::FindAccessibilityPage.human(:type) => [:audit, :find_accessibility_page, :url],

--- a/app/helpers/check_helper.rb
+++ b/app/helpers/check_helper.rb
@@ -1,8 +1,18 @@
 module CheckHelper
   # FIXME: the `custom_badge_*` methods should not live in the model
   # but in some kind of decorator/presenter/facade pattern thing
+
+  STATUS_TO_BADGE_LEVEL = {
+    pending:   :info,
+    blocked:   :info,
+    ready:     :info,
+    running:   :info,
+    completed: :success,
+    failed:    :error,
+  }
+
   def status_to_badge_text(check)
-    if check.passed? && check.respond_to?(:custom_badge_text)
+    if check.completed? && check.respond_to?(:custom_badge_text)
       check.custom_badge_text
     else
       check.human_status
@@ -10,20 +20,16 @@ module CheckHelper
   end
 
   def status_link(check)
-    return nil if not check.passed?
+    return nil if not check.completed?
 
     check.custom_badge_link if check.respond_to?(:custom_badge_link)
   end
 
   def status_to_badge_level(check)
-    if check.failed?
-      :error
-    elsif check.pending? || check.blocked?
-      :info
-    elsif check.passed? && check.respond_to?(:custom_badge_status)
+    if check.completed? && check.respond_to?(:custom_badge_status)
       check.custom_badge_status
     else
-      :success
+      STATUS_TO_BADGE_LEVEL[check.current_state.to_sym]
     end
   end
 

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -7,12 +7,13 @@ class RunCheckJob < ApplicationJob
   end
 
   before_perform do |job|
-    jobs.arguments.first.tap do |job|
-      if job.in_state?(:running) # retry
-        job.increment!(:retry_count)
-      else
-        job.transition_to!(:running)
-      end
+    check = job.arguments.first
+
+    case check.current_state
+    when "ready"
+      check.transition_to!(:running)
+    when "running" # retry
+      check.increment!(:retry_count)
     end
   end
 

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,9 +1,11 @@
+require "json/add/exception" # required to serialize errors as JSON
+
 class RunCheckJob < ApplicationJob
   queue_as :default
 
   retry_on Check::RuntimeError, wait: 3.seconds, attempts: Check::MAX_RETRIES do |job, exception|
     # this block runs when we're out of retries
-    job.arguments.first.transition_to!(:failed, exception)
+    job.arguments.first.transition_to!(:failed, exception.cause.as_json)
   end
 
   before_perform do |job|

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -22,6 +22,6 @@ class RunCheckJob < ApplicationJob
   end
 
   def perform(check)
-    check.run
+    check.run!
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -32,6 +32,14 @@ class Audit < ApplicationRecord
     Check.types.map { |name, klass| send(name) || checks.build(type: klass) }
   end
 
+  def check_for(identifier)
+    send(identifier)
+  end
+
+  def check_complete?(identifier)
+    check_for(identifier).complete?
+  end
+
   def check_status(check)
     (send(check)&.status || :pending).to_s.inquiry
   end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -62,4 +62,8 @@ class Audit < ApplicationRecord
       site.set_current_audit! unless pending?
     end
   end
+
+  def after_check_completed(check)
+    ProcessAuditJob.perform_later(self)
+  end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -66,4 +66,11 @@ class Audit < ApplicationRecord
   def after_check_completed(check)
     ProcessAuditJob.perform_later(self)
   end
+
+  def abort_dependent_checks!(check)
+    checks
+      .remaining
+      .filter { |other_check| other_check.depends_on?(check.to_requirement) }
+      .each   { |other_check| other_check.transition_to!(:failed) }
+  end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -63,8 +63,16 @@ class Audit < ApplicationRecord
     end
   end
 
+  def complete?
+    checks.remaining.none?
+  end
+
   def after_check_completed(check)
-    ProcessAuditJob.perform_later(self)
+    if complete?
+      update!(checked_at: Time.zone.now)
+    else
+      ProcessAuditJob.perform_later(self)
+    end
   end
 
   def abort_dependent_checks!(check)

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -117,6 +117,12 @@ class Check < ApplicationRecord
       .to_sym
   end
 
+  def error
+    return unless failed?
+
+    last_transition.metadata
+  end
+
   private
 
   def analyze! = raise NotImplementedError.new("#{model_name} needs to implement the `#{__method__}` private method")

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -106,6 +106,17 @@ class Check < ApplicationRecord
     in_state?(:blocked?)
   end
 
+  def depends_on?(requirement)
+    requirements.include?(requirement)
+  end
+
+  def to_requirement
+    type
+      .demodulize
+      .underscore
+      .to_sym
+  end
+
   private
 
   def analyze! = raise NotImplementedError.new("#{model_name} needs to implement the `#{__method__}` private method")

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -73,7 +73,7 @@ class Check < ApplicationRecord
   def requirements = self.class::REQUIREMENTS # Returns subclass constant value, defaults to parent class
   def tooltip? = true
 
-  def run
+  def run!
     self.data = analyze!
 
     save!

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -56,6 +56,7 @@ class Check < ApplicationRecord
 
   scope :prioritized, -> { order(:priority) }
   scope :remaining, -> { in_state(:pending, :blocked) }
+  scope :errored, -> { in_state(:failed) }
 
   broadcasts_refreshes_to ->(check) { "sites" }
 

--- a/app/models/check_state_machine.rb
+++ b/app/models/check_state_machine.rb
@@ -10,13 +10,17 @@ class CheckStateMachine
   state :failed
   state :completed
 
-  transition from: :pending, to: [:ready, :blocked]
+  transition from: :pending, to: [:ready, :blocked, :failed]
   transition from: :ready,   to: [:running]
   transition from: :running, to: [:failed, :completed]
   transition from: :blocked, to: [:ready]
 
   guard_transition(to: :ready) do |check|
     check.all_requirements_met?
+  end
+
+  after_transition(to: :failed) do |check|
+    check.audit.abort_dependent_checks!(check)
   end
 
   after_transition(to: :completed) do |check|

--- a/app/models/check_state_machine.rb
+++ b/app/models/check_state_machine.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CheckStateMachine
+  include Statesman::Machine
+
+  state :pending, initial: true
+  state :ready
+  state :blocked
+  state :running
+  state :failed
+  state :completed
+
+  transition from: :pending, to: [:ready, :blocked]
+  transition from: :ready,   to: [:running]
+  transition from: :running, to: [:failed, :completed]
+  transition from: :blocked, to: [:ready]
+
+  before_transition(to: :running) do |check|
+    check.all_requirements_met?
+  end
+end

--- a/app/models/check_state_machine.rb
+++ b/app/models/check_state_machine.rb
@@ -15,7 +15,7 @@ class CheckStateMachine
   transition from: :running, to: [:failed, :completed]
   transition from: :blocked, to: [:ready]
 
-  before_transition(to: :running) do |check|
+  guard_transition(to: :ready) do |check|
     check.all_requirements_met?
   end
 end

--- a/app/models/check_state_machine.rb
+++ b/app/models/check_state_machine.rb
@@ -18,4 +18,8 @@ class CheckStateMachine
   guard_transition(to: :ready) do |check|
     check.all_requirements_met?
   end
+
+  after_transition(to: :completed) do |check|
+    check.audit.after_check_completed(check)
+  end
 end

--- a/app/models/check_transition.rb
+++ b/app/models/check_transition.rb
@@ -1,0 +1,15 @@
+class CheckTransition < ApplicationRecord
+  belongs_to :check, inverse_of: :check_transitions
+
+  validates :to_state, inclusion: { in: CheckStateMachine.states }
+
+  after_destroy :update_most_recent, if: :most_recent?
+
+  private
+
+  def update_most_recent
+    last_transition = check.check_transitions.order(:sort_key).last
+    return unless last_transition.present?
+    last_transition.update_column(:most_recent, true)
+  end
+end

--- a/app/models/checks/analyze_accessibility_page.rb
+++ b/app/models/checks/analyze_accessibility_page.rb
@@ -23,7 +23,7 @@ module Checks
 
     store_accessor :data, :audit_date, :audit_update_date, :compliance_rate, :standard, :auditor
 
-    def tooltip? = !(passed? && found_required?)
+    def tooltip? = !(completed? && found_required?)
     def audit_date = super&.to_date
     def audit_update_date = super&.to_date
     def human_compliance_rate = helpers.number_to_percentage(compliance_rate, precision: 2, strip_insignificant_zeros: true)

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -13,7 +13,7 @@ module Checks
     end
 
     PRIORITY = 0 # This needs to run before all other checks
-    REQUIREMENTS = nil
+    REQUIREMENTS = []
 
     store_accessor :data, :original_url, :redirect_url
 

--- a/app/models/checks/run_axe_on_homepage.rb
+++ b/app/models/checks/run_axe_on_homepage.rb
@@ -4,10 +4,10 @@ module Checks
 
     store_accessor :data, :passes, :incomplete, :inapplicable, :failures, :violations, :issues_total
 
-    def tooltip? = !passed?
-    def applicable_total = passed? ? passes + incomplete + violations : nil
-    def checks_total = passed? ? applicable_total + inapplicable : nil
-    def success_rate = passed? ? (passes + incomplete) / applicable_total.to_f * 100 : nil
+    def tooltip? = !completed?
+    def applicable_total = completed? ? passes + incomplete + violations : nil
+    def checks_total = completed? ? applicable_total + inapplicable : nil
+    def success_rate = completed? ? (passes + incomplete) / applicable_total.to_f * 100 : nil
     def human_success_rate = to_percent(success_rate)
 
     def violation_data

--- a/app/views/checks/_accessibility_page_heading.html.erb
+++ b/app/views/checks/_accessibility_page_heading.html.erb
@@ -5,14 +5,14 @@
   <p>
     <%= check.human(:allowed_level_differences) %>
     <br>
-    <% if check.passed? && check.comparison.present? %>
+    <% if check.completed? && check.comparison.present? %>
     <%= check.human_explanation %>
     <% else %>
       <%= check.human(:expectations) %>
     <% end %>
   </p>
   <ul class="fr-raw-list fr-mt-2w">
-    <% if check.passed? && check.comparison.present? %>
+    <% if check.completed? && check.comparison.present? %>
       <% check.comparison.each do |heading_status| %>
         <li class="fr-mb-2w">
           <%= heading_status.ok? ? icon(:checkbox, line: true, class: "fr-mr-1v fr-label--success") : icon(:close, :circle, class: "fr-mr-1v fr-label--error") %>

--- a/app/views/checks/_analyze_accessibility_page.html.erb
+++ b/app/views/checks/_analyze_accessibility_page.html.erb
@@ -2,7 +2,7 @@
   <h2 class="fr-h4 fr-mb-1w"><%= check.human_type %></h2>
   <%= badge to_badge(check) %>
 
-  <% if check.passed? %>
+  <% if check.completed? %>
     <ul>
       <li><strong><%= check.human(:compliance_rate) %></strong> : <%= check.human_compliance_rate || check.human(:unknown) %></li>
       <li><strong><%= check.human(:audit_date) %></strong> :

--- a/app/views/checks/_run_axe_on_homepage.html.erb
+++ b/app/views/checks/_run_axe_on_homepage.html.erb
@@ -2,7 +2,7 @@
   <h2 class="fr-h4 fr-mb-1w"><%= check.human_type %></h2>
   <%= badge to_badge(check) %>
 
-  <% if check.passed? %>
+  <% if check.completed? %>
     <ul>
       <li><strong><%= check.human(:checks_total) %></strong> : <%= number_to_human(check.checks_total) || check.human(:unknown) %></li>
       <li><strong><%= check.human(:passes) %></strong> : <%= number_to_human(check.passes) || check.human(:unknown) %></li>

--- a/config/initializers/statesman.rb
+++ b/config/initializers/statesman.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Statesman.configure do
+  storage_adapter(Statesman::Adapters::ActiveRecord)
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -102,7 +102,6 @@ fr:
       check:
         type: Type de contrôle
         status: État
-        run_at: Vérification prévue le
         checked_at: Vérification effectuée le
         attempts: Tentatives
         count:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -111,7 +111,7 @@ fr:
       check/status:
         pending: Planifié
         running: En cours
-        passed: Effectué
+        completed: Effectué
         blocked: Inapplicable
         failed: Échoué
       checks/accessibility_mention:

--- a/db/migrate/20250811081407_create_check_transitions.rb
+++ b/db/migrate/20250811081407_create_check_transitions.rb
@@ -1,0 +1,26 @@
+class CreateCheckTransitions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :check_transitions do |t|
+      t.string :to_state, null: false
+      t.json :metadata, default: {}
+      t.integer :sort_key, null: false
+      t.integer :check_id, null: false
+      t.boolean :most_recent, null: false
+
+      t.timestamps null: false
+    end
+
+    # Foreign keys are optional, but highly recommended
+    add_foreign_key :check_transitions, :checks
+
+    add_index(:check_transitions,
+              %i(check_id sort_key),
+              unique: true,
+              name: "index_check_transitions_parent_sort")
+    add_index(:check_transitions,
+              %i(check_id most_recent),
+              unique: true,
+              where: "most_recent",
+              name: "index_check_transitions_parent_most_recent")
+  end
+end

--- a/db/migrate/20250811134440_remove_state_attributes_on_checks.rb
+++ b/db/migrate/20250811134440_remove_state_attributes_on_checks.rb
@@ -1,0 +1,19 @@
+class RemoveStateAttributesOnChecks < ActiveRecord::Migration[8.0]
+  # Checks now use a state machine with a dedicated transition model
+  # (CheckTransition) that offers timestamps, latest_state &
+  # metadata, removing the need to store retry_at/checked_at
+  # (transitions have timestamps) or error status (which now belongs
+  # in the `failed' transition's metadata)
+  def change
+    remove_index  :checks, column: [:status, :run_at]
+
+    remove_column :checks, :run_at, :datetime
+    remove_column :checks, :status, :string, null: false
+    remove_column :checks, :checked_at, :datetime
+    remove_column :checks, :retry_at, :datetime
+
+    remove_column :checks, :error_type, :string
+    remove_column :checks, :error_message, :text
+    remove_column :checks, :error_backtrace, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_07_100904) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_11_081407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_07_100904) do
     t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"
     t.index ["url"], name: "index_audits_on_url"
+  end
+
+  create_table "check_transitions", force: :cascade do |t|
+    t.string "to_state", null: false
+    t.json "metadata", default: {}
+    t.integer "sort_key", null: false
+    t.integer "check_id", null: false
+    t.boolean "most_recent", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["check_id", "most_recent"], name: "index_check_transitions_parent_most_recent", unique: true, where: "most_recent"
+    t.index ["check_id", "sort_key"], name: "index_check_transitions_parent_sort", unique: true
   end
 
   create_table "checks", force: :cascade do |t|
@@ -120,6 +132,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_07_100904) do
   end
 
   add_foreign_key "audits", "sites"
+  add_foreign_key "check_transitions", "checks"
   add_foreign_key "checks", "audits"
   add_foreign_key "sessions", "users"
   add_foreign_key "site_tags", "sites"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_081407) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_11_134440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,20 +43,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_11_081407) do
   create_table "checks", force: :cascade do |t|
     t.bigint "audit_id", null: false
     t.string "type", null: false
-    t.string "status", null: false
-    t.datetime "checked_at"
     t.jsonb "data", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "priority", default: 100, null: false
-    t.string "error_type"
-    t.text "error_message"
-    t.string "error_backtrace", default: [], array: true
-    t.datetime "retry_at"
     t.integer "retry_count", default: 0, null: false
-    t.datetime "run_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["audit_id"], name: "index_checks_on_audit_id"
-    t.index ["status", "run_at"], name: "index_checks_on_status_and_run_at"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     volumes:
       - "./:/app"
       - "/app/node_modules"
+    depends_on:
+      - db
   css-watcher:
     <<: *server
     command: ["bin/rails", "dartsass:watch"]

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -3,6 +3,12 @@ FactoryBot.define do
     url { "https://example.com" }
     site { association :site, url:, audits: [instance] }
 
+    trait :without_checks do
+      after(:create) do |audit, _eval|
+        audit.checks.destroy_all
+      end
+    end
+
     trait :pending do
       status { "pending" }
     end

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
-  factory :accessibility_mention_check, class: "Checks::AccessibilityMention", aliases: [:check] do
+  factory :check do
     audit { association :audit }
+
+    Check.types.each do |type, klass|
+      factory("#{type}_check", class: klass)
+    end
 
     # we could try and emulate the complete logic of going through the
     # chain of states (pending -> ready -> running, etc) but it would

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -2,9 +2,22 @@ FactoryBot.define do
   factory :accessibility_mention_check, class: "Checks::AccessibilityMention", aliases: [:check] do
     audit { association :audit }
 
-    trait :ready do
-      after(:create) do |check, _eval|
-        CheckTransition.create!(to_state: "ready", check: check, most_recent: true, sort_key: 10)
+    # we could try and emulate the complete logic of going through the
+    # chain of states (pending -> ready -> running, etc) but it would
+    # require a lot of heavy machinery since Checks have requirements
+    # + runtime logic (like running browser things). Instead, insert
+    # the last transition as STATE and run with it: it might be
+    # exactly the right kind of dumb we want for testing.
+    CheckStateMachine.states.each do |state|
+      trait(state) do
+        after(:create) do |check, _eval|
+          CheckTransition.create!(
+            to_state: state,
+            check: check,
+            most_recent: true,
+            sort_key: 0
+          )
+        end
       end
     end
   end

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     audit { association :audit }
 
     Check.types.each do |type, klass|
-      factory("#{type}_check", class: klass)
+      trait(type) do
+        initialize_with { klass.new(attributes) }
+      end
     end
 
     # we could try and emulate the complete logic of going through the

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :accessibility_mention_check, class: "Checks::AccessibilityMention", aliases: [:check] do
     audit { association :audit }
+
+    trait :ready do
+      after(:create) do |check, _eval|
+        CheckTransition.create!(to_state: "ready", check: check, most_recent: true, sort_key: 10)
+      end
+    end
   end
 end

--- a/spec/helpers/check_helper_spec.rb
+++ b/spec/helpers/check_helper_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CheckHelper do
       end
     end
 
-    context "when the check is in the passed state" do
+    context "when the check is in the completed state" do
       let(:state) { :completed }
 
       context "with a custom badge level" do

--- a/spec/helpers/check_helper_spec.rb
+++ b/spec/helpers/check_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CheckHelper do
-  let(:check) { create(:accessibility_mention_check, state) }
+  let(:check) { create(:check, :accessibility_mention, state) }
   let(:state) { nil }
 
   describe "#status_to_badge_text" do

--- a/spec/helpers/check_helper_spec.rb
+++ b/spec/helpers/check_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CheckHelper do
-  let(:check) { create(:check, state) }
+  let(:check) { create(:accessibility_mention_check, state) }
   let(:state) { nil }
 
   describe "#status_to_badge_text" do

--- a/spec/jobs/process_audit_job_spec.rb
+++ b/spec/jobs/process_audit_job_spec.rb
@@ -2,16 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProcessAuditJob do
   let(:site) { create(:site) }
-  let(:audit) { create(:audit, site: site) }
-
-  # we want to control the output of `audit.checks` (otherwise lots of
-  # things will break when we update the default checks) and that is
-  # very hard to mock (mocking A/R scopes is essentially a bad
-  # idea). In the meantime, remove all checks and add ours, it's not
-  # great but it works.
-  before "remove all existing checks" do
-    audit.checks.destroy_all
-  end
+  let(:audit) { create(:audit, :without_checks, site: site) }
 
   context 'when there are checks that can move to ready' do
     before do

--- a/spec/jobs/process_audit_job_spec.rb
+++ b/spec/jobs/process_audit_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProcessAuditJob do
 
   context 'when there are checks that can move to ready' do
     before do
-      create(:reachable_check, audit: audit)
+      create(:check, :reachable, audit: audit)
     end
 
     it 'enqueues RunCheckJob with all the checks that are ready' do
@@ -18,7 +18,7 @@ RSpec.describe ProcessAuditJob do
 
   context "when there are no jobs that can move to ready" do
     before do
-      create(:reachable_check, :running, audit: audit)
+      create(:check, :reachable, :running, audit: audit)
     end
 
     it "does not enqueue any job" do

--- a/spec/jobs/process_audit_job_spec.rb
+++ b/spec/jobs/process_audit_job_spec.rb
@@ -6,18 +6,14 @@ RSpec.describe ProcessAuditJob do
 
   describe '#perform' do
     context 'when there are checks to process' do
-      it 'launches RunCheckJob with the next check' do
-        check = audit.checks.first
-        allow(audit).to receive(:next_check).and_return(check)
-        allow(RunCheckJob).to receive(:perform_later)
+      it 'launches RunCheckJob with all the checks that are ready' do
+        ActiveJob::Base.queue_adapter = :test
 
-        described_class.new.perform(audit)
-
-        expect(RunCheckJob).to have_received(:perform_later).with(check)
+        expect { described_class.perform_now(audit) }.to have_enqueued_job(RunCheckJob).exactly(:once)
       end
     end
 
-    context 'when there are no checks to process' do
+    xcontext 'when there are no checks to process' do
       it 'does not launch RunCheckJob' do
         allow(audit).to receive(:next_check).and_return(nil)
         allow(RunCheckJob).to receive(:perform_later)

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe RunCheckJob do
-  let(:check) { create(:accessibility_mention_check, :ready) }
+  let(:check) { create(:check, :accessibility_mention, :ready) }
 
   context "when the check goes well" do
     before do

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -45,7 +45,13 @@ RSpec.describe RunCheckJob do
         described_class.perform_later(check)
       end
 
-      expect(check.state_machine.last_transition.metadata).to include "cry cry"
+      error_metadata = check.state_machine.last_transition.metadata
+
+      expect(error_metadata)
+        .to include(
+              "json_class" => "Ferrum::TimeoutError",
+              "m" => /Timed out/
+            )
     end
   end
 end

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe RunCheckJob do
   include ActiveJob::TestHelper
 
-  let(:check) { create(:check, :ready) }
+  let(:check) { create(:accessibility_mention_check, :ready) }
 
   context "when the check goes well" do
     before do
@@ -11,7 +11,7 @@ RSpec.describe RunCheckJob do
       # since ActiveJob deserializes models with GlobalID, mocking the
       # object here will have no effect when ActiveJob reinstantiates
       # a model on its side.
-      allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Check) # rubocop:disable RSpec/AnyInstance
         .to receive(:run!).and_return :test_success
     end
 

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RunCheckJob do
       # object here will have no effect when ActiveJob reinstantiates
       # a model on its side.
       allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
-        .to receive(:run).and_return :test_success
+        .to receive(:run!).and_return :test_success
     end
 
     it "transitions the check to completed" do
@@ -28,7 +28,7 @@ RSpec.describe RunCheckJob do
   context "when the check does not go well" do
     before do
       allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
-        .to receive(:run).and_raise Check::RuntimeError.new("cry cry")
+        .to receive(:analyze!).and_raise Ferrum::TimeoutError.new("Test error")
     end
 
     it "transitions the check to failed" do

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -45,13 +45,11 @@ RSpec.describe RunCheckJob do
         described_class.perform_later(check)
       end
 
-      error_metadata = check.state_machine.last_transition.metadata
-
-      expect(error_metadata)
+      expect(check.error)
         .to include(
-              "json_class" => "Ferrum::TimeoutError",
-              "m" => /Timed out/
-            )
+          "json_class" => "Ferrum::TimeoutError",
+          "m" => /Timed out/
+        )
     end
   end
 end

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe RunCheckJob do
-  include ActiveJob::TestHelper
-
   let(:check) { create(:accessibility_mention_check, :ready) }
 
   context "when the check goes well" do

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe Audit do
   describe "abort_dependent_checks!" do
     let(:audit) { create(:audit, :without_checks) }
 
-    let(:original_check) { create(:reachable_check, :failed, audit: audit) }
-    let(:dependent_check) { create(:accessibility_mention_check, :pending, audit: audit) }
+    let(:original_check) { create(:check, :reachable, :failed, audit: audit) }
+    let(:dependent_check) { create(:check, :accessibility_mention, :pending, audit: audit) }
 
     before do
       allow(dependent_check)

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -157,4 +157,12 @@ RSpec.describe Audit do
       expect { audit.save! }.to change(Check, :count).by(Check.types.size)
     end
   end
+
+  describe "after a check has completed" do
+    let(:audit) { create(:audit) }
+
+    it "reschedules a ProcessAuditJob with itself" do
+      expect { audit.after_check_completed(nil) }.to have_enqueued_job(ProcessAuditJob).with(audit)
+    end
+  end
 end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -136,4 +136,24 @@ RSpec.describe Check do
       end
     end
   end
+
+  describe "#error" do
+    subject { check.error }
+
+    context "when the check is not failed" do
+      let(:check) { create(:reachable_check, :pending) }
+
+      it { should be_nil }
+    end
+
+    context "when the check has failed" do
+      let(:check) { create(:reachable_check, :failed) }
+
+      before do
+        check.last_transition.update!(metadata: "error")
+      end
+
+      it { should eq "error" }
+    end
+  end
 end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe Check do
         expect { check.run! }.to change(check, :data).from({}).to("result")
       end
     end
+
+    context "when analyze! raises an error" do
+      let(:error) { Ferrum::TimeoutError.new("Test error") }
+
+      before do
+        allow(check).to receive(:analyze!).and_raise(error)
+      end
+
+      it "raises a Check::RuntimeError with the correct root cause" do
+        expect { check.run! }.to raise_error(Check::RuntimeError) do |err|
+          expect(err.cause).to eq error
+        end
+      end
+    end
   end
 
   describe "#priority" do

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Check do
-  subject(:check) { build(:accessibility_mention_check) }
+  subject(:check) { build(:check, :accessibility_mention) }
 
   it { should be_valid }
 
@@ -37,7 +37,7 @@ RSpec.describe Check do
   end
 
   describe "#human_status" do
-    let(:check) { create(:accessibility_mention_check, :pending) }
+    let(:check) { create(:check, :accessibility_mention, :pending) }
 
     it "returns the humanized status" do
       expect(described_class).to receive(:human).with("status.pending")
@@ -49,14 +49,14 @@ RSpec.describe Check do
   describe "#root_page" do
     it "returns a Page with the audit URL" do
       audit = build(:audit, url: "https://example.com/")
-      check = build(:accessibility_mention_check, audit:)
+      check = build(:check, :accessibility_mention, audit:)
       expect(Page).to receive(:new).with(url: "https://example.com/")
       check.root_page
     end
   end
 
   describe "#run" do
-    let(:check) { build(:accessibility_mention_check) }
+    let(:check) { build(:check, :accessibility_mention) }
 
     context "when the analyze method goes well" do
       before do
@@ -141,13 +141,13 @@ RSpec.describe Check do
     subject { check.error }
 
     context "when the check is not failed" do
-      let(:check) { create(:reachable_check, :pending) }
+      let(:check) { create(:check, :reachable, :pending) }
 
       it { should be_nil }
     end
 
     context "when the check has failed" do
-      let(:check) { create(:reachable_check, :failed) }
+      let(:check) { create(:check, :reachable, :failed) }
 
       before do
         check.last_transition.update!(metadata: "error")

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Check do
       end
 
       it "saves the result" do
-        expect { check.run }.to change(check, :data).from({}).to("result")
+        expect { check.run! }.to change(check, :data).from({}).to("result")
       end
     end
   end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Check do
-  subject(:check) { build(:check) }
-
-  let(:retryable_error) { Check::RETRYABLE_ERRORS.first }
+  subject(:check) { build(:accessibility_mention_check) }
 
   it { should be_valid }
 
@@ -39,7 +37,7 @@ RSpec.describe Check do
   end
 
   describe "#human_status" do
-    let(:check) { create(:check, :pending) }
+    let(:check) { create(:accessibility_mention_check, :pending) }
 
     it "returns the humanized status" do
       expect(described_class).to receive(:human).with("status.pending")
@@ -51,14 +49,14 @@ RSpec.describe Check do
   describe "#root_page" do
     it "returns a Page with the audit URL" do
       audit = build(:audit, url: "https://example.com/")
-      check = build(:check, audit:)
+      check = build(:accessibility_mention_check, audit:)
       expect(Page).to receive(:new).with(url: "https://example.com/")
       check.root_page
     end
   end
 
   describe "#run" do
-    let(:check) { build(:check) }
+    let(:check) { build(:accessibility_mention_check) }
 
     context "when the analyze method goes well" do
       before do

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -11,43 +11,9 @@ RSpec.describe Check do
     it { should belong_to(:audit) }
   end
 
-  describe "enums" do
-    it do
-      should define_enum_for(:status)
-        .validating
-        .with_values(["pending", "passed", "failed", "blocked"].index_by(&:itself))
-        .backed_by_column_of_type(:string)
-        .with_default(:pending)
-    end
-  end
-
   describe "delegations" do
     it { should delegate_method(:parsed_url).to(:audit) }
     it { should delegate_method(:human_type).to(:class) }
-  end
-
-  describe "scopes" do
-    let!(:pending_check) { create(:check, status: :pending, run_at: 1.hour.ago) }
-    let!(:future_check) { create(:check, status: :pending, run_at: 1.hour.from_now) }
-    let!(:passed_check) { create(:check, status: :passed) }
-    let!(:failed_check_retryable) { create(:check, status: :failed, retry_count: 1, retry_at: 1.hour.ago, error_type: retryable_error) }
-    let!(:failed_check_max_retries) { create(:check, status: :failed, retry_count: 3, retry_at: 1.hour.ago, error_type: retryable_error) }
-    let!(:blocked_check_retryable) { create(:check, status: :blocked, retry_count: 0, retry_at: 1.hour.ago, error_type: retryable_error) }
-    let!(:future_retry_check) { create(:check, status: :failed, retry_count: 1, retry_at: 1.hour.from_now) }
-
-    describe ".to_run" do
-      it "returns due and retryable checks" do
-        expect(described_class.to_run).to include(pending_check)
-        expect(described_class.to_run).not_to include(future_check, passed_check)
-      end
-    end
-
-    describe ".to_retry" do
-      it "returns failed or blocked checks that can be retried and are due" do
-        expect(described_class.to_retry).to include(failed_check_retryable, blocked_check_retryable)
-        expect(described_class.to_retry).not_to include(future_retry_check, failed_check_max_retries, pending_check)
-      end
-    end
   end
 
   describe "class methods" do
@@ -72,67 +38,13 @@ RSpec.describe Check do
     end
   end
 
-  describe "#run_at" do
-    context "when run_at is set" do
-      it "returns the set time" do
-        time = 1.hour.ago
-        check = build(:check, run_at: time)
-        expect(check.run_at).to be_within(1.second).of(time)
-      end
-    end
-
-    context "when run_at is nil" do
-      it "returns current time" do
-        check = build(:check, run_at: nil, audit: nil)
-        expect(check.run_at).to be_within(1.second).of(Time.current)
-      end
-    end
-  end
-
   describe "#human_status" do
+    let(:check) { create(:check, :pending) }
+
     it "returns the humanized status" do
-      check = build(:check, status: :pending)
       expect(described_class).to receive(:human).with("status.pending")
+
       check.human_status
-    end
-  end
-
-  describe "#human_checked_at" do
-    context "when checked_at is present" do
-      it "formats the checked_at timestamp" do
-        time = Time.zone.parse("2024-02-14 10:00:00")
-        check = build(:check, checked_at: time)
-        expect(check.human_checked_at).to eq(I18n.l(time, format: :long))
-      end
-    end
-
-    context "when checked_at is nil" do
-      it "returns nil" do
-        check = build(:check, checked_at: nil)
-        expect(check.human_checked_at).to be_nil
-      end
-    end
-  end
-
-  describe "#due?" do
-    it "returns true for persisted pending checks with past run_at" do
-      check = create(:check, status: :pending, run_at: 1.minute.ago)
-      expect(check).to be_due
-    end
-
-    it "returns false for new records" do
-      check = build(:check, status: :pending, run_at: 1.minute.ago)
-      expect(check).not_to be_due
-    end
-
-    it "returns false for pending checks with future run_at" do
-      check = create(:check, status: :pending, run_at: 1.minute.from_now)
-      expect(check).not_to be_due
-    end
-
-    it "returns false for non-pending checks" do
-      check = create(:check, status: :passed, run_at: 1.minute.ago)
-      expect(check).not_to be_due
     end
   end
 
@@ -148,219 +60,13 @@ RSpec.describe Check do
   describe "#run" do
     let(:check) { build(:check) }
 
-    context "when check is waiting on requirements" do
+    context "when the analyze method goes well" do
       before do
-        allow(check).to receive(:waiting?).and_return(true)
+        allow(check).to receive(:analyze!).and_return :result
       end
 
-      it "returns false without running" do
-        expect(check.run).to be false
-      end
-
-      it "does not call analyze!" do
-        expect(check).not_to receive(:analyze!)
-        check.run
-      end
-    end
-
-    context "when check is blocked by failed requirements" do
-      before do
-        allow(check).to receive_messages(waiting?: false, blocked?: true)
-      end
-
-      it "sets status to blocked" do
-        check.run
-        expect(check.status).to eq("blocked")
-      end
-
-      it "sets checked_at timestamp" do
-        freeze_time do
-          check.run
-          expect(check.checked_at).to eq(Time.zone.now)
-        end
-      end
-
-      it "sets retry_at for future retry" do
-        # Mock the retryable? method to return true since blocked checks should be retryable
-        allow(check).to receive(:retryable?).and_return(true)
-        check.run
-        expect(check.retry_at).to be > Time.current
-      end
-
-      it "returns false" do
-        expect(check.run).to be false
-      end
-
-      it "does not call analyze!" do
-        expect(check).not_to receive(:analyze!)
-        check.run
-      end
-    end
-
-    context "when check is not ready to retry yet" do
-      before do
-        allow(check).to receive_messages(waiting?: false, blocked?: false)
-        check.retry_at = 1.hour.from_now
-      end
-
-      it "returns false without running" do
-        expect(check.run).to be false
-      end
-
-      it "does not call analyze!" do
-        expect(check).not_to receive(:analyze!)
-        check.run
-      end
-    end
-
-    context "when check requirements are met" do
-      before do
-        allow(check).to receive_messages(waiting?: false, analyze!: { result: "success" })
-      end
-
-      it "calls analyze!" do
-        allow(check).to receive(:analyze!).and_return({ result: "success" })
-        check.run
-        expect(check).to have_received(:analyze!)
-      end
-
-      it "updates the check status to passed" do
-        check.run
-        expect(check.status).to eq("passed")
-      end
-
-      it "sets the data with analyze! results" do
-        check.run
-        expect(check.data).to eq({ "result" => "success" })
-      end
-
-      it "updates checked_at timestamp" do
-        freeze_time do
-          check.run
-          expect(check.checked_at).to eq(Time.zone.now)
-        end
-      end
-
-      it "resets retry_at to nil" do
-        check.retry_at = 1.hour.ago
-        check.run
-        expect(check.retry_at).to be_nil
-      end
-
-      it "clears error details on pass" do
-        check.error_type = "SomeError"
-        check.error_message = "Some message"
-        check.error_backtrace = ["line 1"]
-        check.run
-        expect(check.error_type).to be_nil
-        expect(check.error_message).to be_nil
-        expect(check.error_backtrace).to be_nil
-      end
-
-      it "returns true when passed" do
-        expect(check.run).to be true
-      end
-    end
-
-    context "when analyze! raises an error" do
-      let(:error) { Ferrum::TimeoutError.new("Test error") }
-
-      before do
-        allow(check).to receive(:waiting?).and_return(false)
-        allow(check).to receive(:analyze!).and_raise(error)
-        allow(Rails.backtrace_cleaner).to receive(:clean).and_return(["backtrace line"])
-      end
-
-      it "catches the error and sets status to failed" do
-        check.run
-        expect(check.status).to eq("failed")
-      end
-
-      it "stores error details in dedicated columns" do
-        check.run
-        expect(check.error_type).to eq("Ferrum::TimeoutError")
-        expect(check.error_message).to be_present
-        expect(check.error_backtrace).to include("backtrace line")
-      end
-
-      it "updates checked_at timestamp" do
-        freeze_time do
-          check.run
-          expect(check.checked_at).to eq(Time.zone.now)
-        end
-      end
-
-      it "increments retry_count" do
-        check.retry_count = 1
-        check.run
-        expect(check.retry_count).to eq(2)
-      end
-
-      it "sets retry_at" do
-        check.retry_count = 1
-        check.run
-        expect(check.retry_at).to be > Time.current
-      end
-
-      it "returns false" do
-        expect(check.run).to be false
-      end
-    end
-  end
-
-  describe "#retryable?" do
-    it "returns true when check is failed, retry_count is less than max_retries, and error_type is retryable" do
-      check = build(:check, status: :failed, retry_count: 2, error_type: retryable_error)
-      expect(check).to be_retryable
-    end
-
-    it "returns false when retry_count is equal to max_retries" do
-      check = build(:check, status: :failed, retry_count: 3, error_type: retryable_error)
-      expect(check).not_to be_retryable
-    end
-
-    it "returns false when retry_count is greater than max_retries" do
-      check = build(:check, status: :failed, retry_count: 4, error_type: retryable_error)
-      expect(check).not_to be_retryable
-    end
-
-    it "returns false when check is not failed" do
-      check = build(:check, status: :blocked, retry_count: 1, error_type: retryable_error)
-      expect(check).not_to be_retryable
-    end
-
-    it "returns false when error_type is not retryable" do
-      check = build(:check, status: :failed, retry_count: 1, error_type: "SomeOtherError")
-      expect(check).not_to be_retryable
-    end
-
-    it "returns false when error_type is nil" do
-      check = build(:check, status: :failed, retry_count: 1, error_type: nil)
-      expect(check).not_to be_retryable
-    end
-  end
-
-  describe "#calculate_retry_at" do
-    let(:check) { build(:check, status: :failed, retry_count:, error_type: retryable_error) }
-    let(:retry_count) { 1 }
-
-    it "calculates exponential backoff based on retry_count" do
-      freeze_time do
-        # For retry_count = 1: 5 * (5^1) = 25 minutes
-        expected_time = Time.current + 25.minutes
-        expect(check.calculate_retry_at).to be_within(1.second).of(expected_time)
-      end
-    end
-
-    context "with different retry counts" do
-      let(:retry_count) { 2 }
-
-      it "applies exponential backoff correctly" do
-        freeze_time do
-          # For retry_count = 2: 5 * (5^2) = 5 * 25 = 125 minutes
-          expected_time = Time.current + 125.minutes
-          expect(check.calculate_retry_at).to be_within(1.second).of(expected_time)
-        end
+      it "saves the result" do
+        expect { check.run }.to change(check, :data).from({}).to("result")
       end
     end
   end
@@ -415,86 +121,6 @@ RSpec.describe Check do
       it "defaults to Check::REQUIREMENTS" do
         check = default_check_class.new
         expect(check.requirements).to eq(described_class::REQUIREMENTS)
-      end
-    end
-  end
-
-  describe "#waiting?" do
-    let(:audit) { instance_double(Audit) }
-    let(:check) { build(:check, audit: nil) }
-    let(:check_status) { :passed }
-    let(:inquiry) { check_status.to_s.inquiry }
-
-    before do
-      allow(check).to receive_messages(audit:, requirements:)
-      allow(audit).to receive(:check_status).with(anything).and_return(inquiry)
-    end
-
-    context "when requirements are nil" do
-      let(:requirements) { nil }
-
-      it "returns false" do
-        expect(check.waiting?).to be false
-      end
-    end
-
-    context "when requirements are present" do
-      let(:requirements) { [:reachable] }
-
-      context "when any required check is pending" do
-        let(:check_status) { :pending }
-
-        it "returns true" do
-          expect(check.waiting?).to be true
-        end
-      end
-
-      context "when all required checks passed" do
-        let(:check_status) { :passed }
-
-        it "returns false" do
-          expect(check.waiting?).to be false
-        end
-      end
-    end
-  end
-
-  describe "#blocked?" do
-    let(:audit) { instance_double(Audit) }
-    let(:check) { build(:check, audit: nil) }
-    let(:check_status) { :passed }
-    let(:inquiry) { check_status.to_s.inquiry }
-
-    before do
-      allow(check).to receive_messages(audit:, requirements:)
-      allow(audit).to receive(:check_status).with(anything).and_return(inquiry)
-    end
-
-    context "when requirements are nil" do
-      let(:requirements) { nil }
-
-      it "returns false" do
-        expect(check.blocked?).to be false
-      end
-    end
-
-    context "when requirements are present" do
-      let(:requirements) { [:reachable] }
-
-      context "when any required check is pending" do
-        let(:check_status) { :failed }
-
-        it "returns true" do
-          expect(check.blocked?).to be true
-        end
-      end
-
-      context "when all required checks passed" do
-        let(:check_status) { :passed }
-
-        it "returns false" do
-          expect(check.blocked?).to be false
-        end
       end
     end
   end

--- a/spec/models/check_state_machine_spec.rb
+++ b/spec/models/check_state_machine_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CheckStateMachine do
+  let(:machine) { check.state_machine }
+  let(:check) { create(:reachable_check) }
+
+  context "when moving to ready" do
+    context "when the requirements aren't met" do
+      before do
+        allow(check).to receive(:all_requirements_met?).and_return false
+      end
+
+      it "raises an error" do
+        expect { machine.transition_to!(:ready) }
+          .to raise_error Statesman::GuardFailedError
+      end
+    end
+  end
+
+  context "when moving to completed" do
+    let(:check) { create(:reachable_check, :running) }
+
+    it "calls back to the audit" do
+      expect(check.audit).to receive(:after_check_completed).with(check)
+
+      check.transition_to!(:completed)
+    end
+  end
+end

--- a/spec/models/check_state_machine_spec.rb
+++ b/spec/models/check_state_machine_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe CheckStateMachine do
   let(:machine) { check.state_machine }
-  let(:check) { create(:reachable_check) }
+  let(:check) { create(:check, :reachable) }
 
   context "when moving to ready" do
     context "when the requirements aren't met" do
@@ -20,7 +20,7 @@ describe CheckStateMachine do
   end
 
   context "when moving to completed" do
-    let(:check) { create(:reachable_check, :running) }
+    let(:check) { create(:check, :reachable, :running) }
 
     it "calls back to the audit" do
       expect(check.audit).to receive(:after_check_completed).with(check)
@@ -30,7 +30,7 @@ describe CheckStateMachine do
   end
 
   context "when moving to failed" do
-    let(:check) { create(:reachable_check, :running) }
+    let(:check) { create(:check, :reachable, :running) }
 
     it "tells the audit to look at dependent jobs" do
       expect(check.audit).to receive(:abort_dependent_checks!).with(check)

--- a/spec/models/check_state_machine_spec.rb
+++ b/spec/models/check_state_machine_spec.rb
@@ -28,4 +28,14 @@ describe CheckStateMachine do
       check.transition_to!(:completed)
     end
   end
+
+  context "when moving to failed" do
+    let(:check) { create(:reachable_check, :running) }
+
+    it "tells the audit to look at dependent jobs" do
+      expect(check.audit).to receive(:abort_dependent_checks!).with(check)
+
+      check.transition_to!(:failed)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,9 @@ RSpec.configure do |config|
     require "view_component/test_helpers"
   end
 
+  # Job-specific config
+  config.include ActiveJob::TestHelper, type: :job
+
   # RSpec Rails uses metadata to mix in different behaviours to your tests,
   # for example enabling you to call `get` and `post` in request specs. e.g.:
   #


### PR DESCRIPTION
# Request for Comments : state-machine pour `Check`

Les checks sont essentiellement des state machines : il y a beaucoup de code qui gère leur progression, suffisamment et je dirais même trop pour ne pas basculer sur une vraie solution de state machine qui offre des avantages indéniables comparé à une version maison : 

## The Good

### définition limpide des états et de leurs changements

On voit presque le diagramme en plissant les yeux :  

```ruby
  state :pending, initial: true
  state :ready
  state :blocked
  state :running
  state :failed
  state :completed

  transition from: :pending, to: [:ready, :blocked]
  transition from: :ready,   to: [:running]
  transition from: :running, to: [:failed, :completed]
  transition from: :blocked, to: [:ready]
```

+impossible de faire des bêtises en essayant de contourner les transitions définies (i.e `pending` -> `blocked` impossible)

### système de callbacks pour entre les états

Ce qui découle sur un code presque transparent : 

```rb
  before_transition(to: :running) do |check|
    check.all_requirements_met?
  end
```

### traçabilité des changements

feature quasi indispensable si Accès-Cible obtient le succès qu'on lui souhaite, et impossible avec la solution actuelle de réécriture de l'attribut enum `state` :

```rb
=> {}
[31] pry(main)> a.check_transitions.pluck(:to_state, :created_at)
=> [
 ["pending", 2025-08-11 14:55:45.819698000 CEST +02:00],
 ["ready", 2025-08-11 14:55:45.845525000 CEST +02:00],
 ["running", 2025-08-11 14:57:27.368774000 CEST +02:00],
 ["completed", 2025-08-11 14:58:18.302476000 CEST +02:00]]
```

### utilisation de l'interface d'ActiveJob pour gérer l'exécution des jobs

La délégation de la logique de changements d'état à ActiveJob et du `retry_on` permet d'alléger grandement l'interface en laissant Rails faire le taff, et en se découplant d'une logique 1) à nous 2) à SolidQueue ou un autre adaptateur en dessous de ActiveJob

```rb
  retry_on Check::RuntimeError, wait: 3.seconds, attempts: Check::MAX_RETRIES do |job, exception|
    # this block runs when we're out of retries
    job.arguments.first.transition_to!(:failed, exception)
  end

  before_perform do |job|
    check = arguments.first

    check.transition_to!(:running) unless check.in_state?(:running) # retrying
  end

  after_perform do |job|
    job.arguments.first.transition_to!(:completed)
  end

  def perform(check)
    check.run
  end
```

## The Bad

### table + join SQL

`statesman` introduit une table distincte pour les transitions, ce qui implique des `joins` pour obtenir le dernier état d'un check ; c'est négligeable la plupart du temps (et des scopes sont dispo pour éviter les N+1) et c'est pas cher payé pour la force tranquille® derrière qui permet d'observer/stocker/analyser la chronologie des checks.

### logique de retry

choix volontaire de ma part, j'ai mis à la poubelle le concept de `retry`, en tout cas de s'en occuper de notre côté métier : un check est exécuté par un job (`RunCheckJob`) qui se charge de le retry sans le faire passer par un état intermédiaire de `state :retry`. Si le job foire foire il est relancé, une fois deux fois trois fois (à affiner avec le mécanisme de `retry_on` de ActiveJob), puis ça termine en `failed` ou `completed`, point final, les retries sont contenus dans ActiveJob et débuggables avec `SolidQueue` en production. Notons qu'il est possible de faire des trucs genre : 

```diff
modified   app/jobs/run_check_job.rb
@@ -10,7 +10,10 @@ class RunCheckJob < ApplicationJob
     jobs
       .arguments
       .first
-      .transition_to!(:running) unless check.in_state?(:running) # retrying
+      .tap do |check|
+      check.increment!(:run_count)
+      check.transition_to!(:running) unless check.in_state?(:running) # retrying
+    end
   end
 ```

pour une visibilité accrue mais qui me semble pas nécessaire pour le moment, i.e la question du "pourquoi est-ce que ça a foiré ?" est toujours valide et adressable, mais la question du "combien d'essais ont été effectués avant que ça plante (et pourquoi" me paraît pas utile au jour le jour ; dans du debug obscur pourquoi pas mais encore une fois il y aura SolidQueue pour aller digger ça.

## The Ugly

en vrai rien – j'ai utilisé `statesman` sur APLyPro et c'est un excellent garde-fou, ça me paraissait assez pertinent ici aussi

Qui dit mieux en +-150 lignes de code ?