### PR TITLE
fix: SiteQuery sorting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.3.0)
     benchmark (0.4.1)
-    betagouv-cucumber-steps (0.0.1)
+    betagouv-cucumber-steps (0.1.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,13 +32,17 @@ module ApplicationHelper
     current_sort = params.dig(:sort, param)&.downcase&.to_sym
     direction = current_sort == :asc ? :desc : :asc
     link_params = params.permit(:page, search: {}).merge(sort: { param => direction })
-    options[:title] ||= t("shared.sort_by", column: text, direction: t("shared.#{direction}"))
+    link_text = t("shared.sort_by", column: text, direction: t("shared.#{direction}"))
+    options[:title] ||= link_text
+    options["aria-label"] ||= link_text
+
     if current_sort.present?
       arrow = [:arrow, direction == :asc ? :down : :up]
     else
       arrow = [:arrow, :up, :down]
     end
-    "#{text} #{link_icon(arrow, text, { params: link_params }, options.merge(btn: :sort, size: :sm, sr_only: true, line: true))}".html_safe
+
+    "#{text} #{link_icon(arrow, "", { params: link_params }, options.merge(btn: :sort, size: :sm, line: true))}".html_safe
   end
 
   def set_focus(selector)

--- a/app/queries/site_query.rb
+++ b/app/queries/site_query.rb
@@ -4,16 +4,16 @@ class SiteQuery < SimpleDelegator
     key, direction = params[:sort]&.to_unsafe_h&.first
     direction = direction.to_s.downcase.to_sym.presence_in(directions) || directions.first
     case key
-    in :url
+    in "url"
       sortable_url = Arel.sql("REGEXP_REPLACE(audits.url, '^https?://(www\.)?', '')")
       subquery = model.with_current_audit
-        .select("sites.*, #{sortable_url} as sortable_url")
-        .order(Arel.sql("sortable_url #{direction}"))
+                      .select("sites.*, #{sortable_url} as sortable_url")
+                      .order(Arel.sql("sortable_url #{direction}"))
       from(subquery, :sites).order(Arel.sql("sortable_url #{direction}"))
-    else # default sort
+    else
       subquery = model.with_current_audit
-        .select("sites.*, audits.checked_at AS last_checked_at")
-        .order(Arel.sql("last_checked_at #{direction} NULLS LAST"))
+                      .select("sites.*, audits.checked_at AS last_checked_at")
+                      .order(Arel.sql("last_checked_at #{direction} NULLS LAST"))
       from(subquery, :sites).order(Arel.sql("last_checked_at #{direction} NULLS LAST, sites.created_at #{direction}"))
     end
   end

--- a/features/page_des_sites.feature
+++ b/features/page_des_sites.feature
@@ -1,0 +1,24 @@
+# language: fr
+
+Fonctionnalité:
+
+  Contexte:
+    Sachant que je suis "marie.curie@gouv.fr" avec le SIRET 123 de l'organisation "DINUM"
+    Et que je me pro-connecte
+    Et que je clique sur "Ajouter un site"
+
+  Scénario: Un agent peut trier les sites par URL croissantes
+    Sachant que je possède un fichier "tmp/sites.csv" qui contient
+      """
+      url
+      https://beta.gouv.fr
+      https://www.suresnes.fr
+      https://numerique.gouv.fr
+      """
+    Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
+    Quand je clique sur "Importer"
+    Et que je clique sur "Trier par Adresse du site croissant"
+    Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
+      | beta.gouv.fr      |
+      | numerique.gouv.fr |
+      | suresnes.fr       |

--- a/spec/queries/site_query_spec.rb
+++ b/spec/queries/site_query_spec.rb
@@ -8,42 +8,43 @@ RSpec.describe SiteQuery do
   describe "#order_by" do
     subject(:result) { query.order_by(params) }
 
-    context "when sort[url]=asc" do
-      let(:request) { { sort: { url: :asc } } }
-
-      # Create audits with domains that will sort alphabetically
-      let!(:apple)  { create(:audit, :passed, :current, url: "https://apple.com") }
-      let!(:banana) { create(:audit, :passed, :current, url: "https://banana.org") }
+    context "when ordering by url" do
+      let!(:apple) { create(:audit, :passed, :current, url: "https://apple.com") }
+      let!(:app) { create(:audit, :passed, :current, url: "http://www.app.apple.com") }
+      let!(:banana) { create(:audit, :passed, :current, url: "https://www.banana.org") }
+      let!(:blog) { create(:audit, :passed, :current, url: "http://blog.beta.com") }
       let!(:carrot) { create(:audit, :passed, :current, url: "https://carrot.bio") }
-      let(:expected_ids) { [apple.site_id, banana.site_id, carrot.site_id] }
 
-      it "sorts sites by their URLs in ascending order" do
-        expect(result.ids).to eq(expected_ids)
+      let(:expected_ids) do
+        [
+          app.site_id,
+          apple.site_id,
+          banana.site_id,
+          blog.site_id,
+          carrot.site_id,
+        ]
       end
 
-      it "ignores protocol and www prefix" do
-        create(:audit, :passed, site: banana.site, url: "http://www.banana.org")
+      context "when sort[url]=asc" do
+        let(:request) { { sort: { url: :asc } } }
 
-        expect(result.ids).to eq(expected_ids)
+        it "sorts sites by their URLs in ascending order" do
+          expect(result.ids).to eq(expected_ids)
+        end
+
+        it "handles multiple different URLs for the same site" do
+          create(:audit, :passed, site: apple.site, url: "https://support.apple.com")
+
+          expect(result.ids).to eq(expected_ids)
+        end
       end
 
-      it "handles multiple different URLs for the same site" do
-        create(:audit, :passed, site: apple.site, url: "https://support.apple.com")
+      context "when sort[url]=desc" do
+        let(:request) { { sort: { url: :desc } } }
 
-        expect(result.ids).to eq(expected_ids)
-      end
-    end
-
-    context "when sort[url]=desc" do
-      let(:request) { { sort: { url: :desc } } }
-
-      let!(:apple)  { create(:audit, :passed, :current, url: "https://apple.com") }
-      let!(:banana) { create(:audit, :passed, :current, url: "https://banana.org") }
-      let!(:carrot) { create(:audit, :passed, :current, url: "https://carrot.bio") }
-      let(:expected_ids) { [apple.site_id, banana.site_id, carrot.site_id] }
-
-      it "sorts sites by their URLs in descending order" do
-        expect(result.ids).to eq(expected_ids.reverse)
+        it "sorts sites by their URLs in descending order" do
+          expect(result.ids).to eq(expected_ids.reverse)
+        end
       end
     end
 


### PR DESCRIPTION
- Fix params matching in SiteQuery order_by to use string instead of symbol
- Add test coverage for URL sorting
- Add [cucumber step](https://github.com/betagouv/betagouv-cucumber-steps/pull/1) for validating table order
- Fix sort icon accessibility by removing duplicate text parameter