### PR TITLE
perf: Prevent permanent check failures from being retried

### DIFF
--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -6,7 +6,7 @@ class RunCheckJob < ApplicationJob
   queue_as :default
 
   rescue_from Check::PermanentError do |exception|
-    arguments.first.transition_to!(:failed, exception.cause.as_json)
+    arguments.first.transition_to!(:failed, (exception.cause || exception).as_json)
   end
 
   retry_on Check::RuntimeError, wait: 1.minute, attempts: MAX_RETRIES do |job, exception|

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -10,13 +10,7 @@ class RunCheckJob < ApplicationJob
 
   before_perform do |job|
     check = job.arguments.first
-
-    case check.current_state
-    when "ready"
-      check.transition_to!(:running)
-    when "running" # retry
-      check.increment!(:retry_count)
-    end
+    check.transition_to!(:running) if check.ready?
   end
 
   after_perform do |job|

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -3,6 +3,10 @@ require "json/add/exception" # required to serialize errors as JSON
 class RunCheckJob < ApplicationJob
   queue_as :default
 
+  rescue_from Check::PermanentError do |exception|
+    arguments.first.transition_to!(:failed, exception.cause.as_json)
+  end
+
   retry_on Check::RuntimeError, wait: 1.minute, attempts: Check::MAX_RETRIES do |job, exception|
     # this block runs when we're out of retries
     job.arguments.first.transition_to!(:failed, exception.cause.as_json)

--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,13 +1,15 @@
 require "json/add/exception" # required to serialize errors as JSON
 
 class RunCheckJob < ApplicationJob
+  MAX_RETRIES = 3
+
   queue_as :default
 
   rescue_from Check::PermanentError do |exception|
     arguments.first.transition_to!(:failed, exception.cause.as_json)
   end
 
-  retry_on Check::RuntimeError, wait: 1.minute, attempts: Check::MAX_RETRIES do |job, exception|
+  retry_on Check::RuntimeError, wait: 1.minute, attempts: MAX_RETRIES do |job, exception|
     # this block runs when we're out of retries
     job.arguments.first.transition_to!(:failed, exception.cause.as_json)
   end

--- a/app/libs/dns.rb
+++ b/app/libs/dns.rb
@@ -1,0 +1,21 @@
+require "timeout"
+require "resolv"
+
+module Dns
+  module_function
+
+  RESOLUTION_TIMEOUT = 10.seconds
+
+  def resolvable?(url)
+    uri = Link.parse(url)
+    host = uri.host
+    return false unless host
+
+    Timeout.timeout(RESOLUTION_TIMEOUT) do
+      Resolv::DNS.new.getaddress(host)
+      true
+    end
+  rescue Resolv::ResolvError, Timeout::Error, URI::InvalidURIError
+    false
+  end
+end

--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -1,11 +1,7 @@
 # Based on https://railsnotes.xyz/blog/ferrum-stealth-browsing
 
-require "timeout"
-require "resolv"
-
 class Browser
   PAGE_TIMEOUT = 1.minute
-  DNS_TIMEOUT = 10.seconds  # Shorter timeout for DNS resolution
   PROCESS_TIMEOUT = 5.minutes
   WINDOW_SIZES = [
     [1366, 768],
@@ -110,19 +106,6 @@ class Browser
         axe.run(document, { runOnly: { type: "rule", values: #{AXE_RULES} }, reporter: "v2"}).then(results => __f(results))
       JS
     end
-  end
-
-  def resolvable?(url)
-    uri = Link.parse(url)
-    host = uri.host
-    return false unless host
-
-    Timeout.timeout(DNS_TIMEOUT) do
-      Resolv::DNS.new.getaddress(host)
-      true
-    end
-  rescue Resolv::ResolvError, Timeout::Error, URI::InvalidURIError
-    false
   end
 
   private

--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -1,7 +1,11 @@
 # Based on https://railsnotes.xyz/blog/ferrum-stealth-browsing
 
+require "timeout"
+require "resolv"
+
 class Browser
   PAGE_TIMEOUT = 1.minute
+  DNS_TIMEOUT = 10.seconds  # Shorter timeout for DNS resolution
   PROCESS_TIMEOUT = 5.minutes
   WINDOW_SIZES = [
     [1366, 768],
@@ -106,6 +110,19 @@ class Browser
         axe.run(document, { runOnly: { type: "rule", values: #{AXE_RULES} }, reporter: "v2"}).then(results => __f(results))
       JS
     end
+  end
+
+  def resolvable?(url)
+    uri = Link.parse(url)
+    host = uri.host
+    return false unless host
+
+    Timeout.timeout(DNS_TIMEOUT) do
+      Resolv::DNS.new.getaddress(host)
+      true
+    end
+  rescue Resolv::ResolvError, Timeout::Error, URI::InvalidURIError
+    false
   end
 
   private

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -39,12 +39,8 @@ class Check < ApplicationRecord
     :run_axe_on_homepage,
   ].freeze
 
-  # Wrapper for retryable errors rescued in run!
+  class PermanentError < Exception; end   # Parent class for errors that should not be retried
   class RuntimeError < StandardError; end
-  # Wrapper for all permanent errors
-  class PermanentError < StandardError; end
-  # Parent error class for errors that should not be retried
-  class NonRetryableError < StandardError; end
 
   PRIORITY = 100 # Override in subclasses if necessary, lower numbers run first
   REQUIREMENTS = [:reachable]
@@ -86,10 +82,8 @@ class Check < ApplicationRecord
     self.data = analyze!
 
     save!
-  rescue NonRetryableError => exception
-    raise Check::PermanentError
   rescue StandardError => exception
-    raise Check::RuntimeError
+    raise Check::RuntimeError, exception.message, cause: exception
   end
 
   def all_requirements_met?

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -75,7 +75,7 @@ class Check < ApplicationRecord
   def human_status = Check.human("status.#{state_machine.current_state}")
   def to_partial_path = model_name.i18n_key.to_s
   def root_page = @root_page ||= Page.new(url: audit.url)
-  def crawler = Crawler.new(audit.url)
+  def crawler(crawl_up_to: nil) = Crawler.new(audit.url, crawl_up_to:)
   def requirements = self.class::REQUIREMENTS # Returns subclass constant value, defaults to parent class
   def tooltip? = true
 

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -48,7 +48,6 @@ class Check < ApplicationRecord
 
   PRIORITY = 100 # Override in subclasses if necessary, lower numbers run first
   REQUIREMENTS = [:reachable]
-  MAX_RETRIES = 3
 
   belongs_to :audit
   has_one :site, through: :audit

--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -15,8 +15,7 @@ module Checks
     private
 
     def analyze!
-      return {} unless (page = find_page)
-
+      page = find_page
       { url: page.url, title: page.title }
     end
 
@@ -29,6 +28,10 @@ module Checks
           false
         end
       end
+    rescue Crawler::NoMatchError => e
+      raise Check::NonRetryableError, "No accessibility page found: #{e.message}", cause: e
+    rescue Crawler::CrawlLimitReachedError => e
+      raise Check::NonRetryableError, "Crawl limit reached: #{e.message}", cause: e
     end
 
     def accessibility_page?(current_page)

--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -28,10 +28,10 @@ module Checks
           false
         end
       end
-    rescue Crawler::NoMatchError => e
-      raise Check::NonRetryableError, "No accessibility page found: #{e.message}", cause: e
-    rescue Crawler::CrawlLimitReachedError => e
-      raise Check::NonRetryableError, "Crawl limit reached: #{e.message}", cause: e
+    rescue Crawler::NoMatchError => exception
+      raise Check::PermanentError, "No accessibility page found: #{exception.message}", cause: exception
+    rescue Crawler::CrawlLimitReachedError => exception
+      raise Check::PermanentError, "Crawl limit reached: #{exception.message}", cause: exception
     end
 
     def accessibility_page?(current_page)

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -12,7 +12,7 @@ module Checks
       end
     end
 
-    class DnsResolutionError < Check::NonRetryableError
+    class DnsResolutionError < Check::PermanentError
       def initialize(url)
         super("DNS resolution failed for #{url}")
       end

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -12,6 +12,12 @@ module Checks
       end
     end
 
+    class DnsResolutionError < Check::NonRetryableError
+      def initialize(url)
+        super("DNS resolution failed for #{url}")
+      end
+    end
+
     PRIORITY = 0 # This needs to run before all other checks
     REQUIREMENTS = []
 
@@ -25,6 +31,7 @@ module Checks
     private
 
     def analyze!
+      raise DnsResolutionError.new(audit.url) unless Browser.resolvable?(audit.url)
       raise BrowserError.new(audit.url) if root_page.status.nil?
       raise UnreachableSiteError.new(audit.url, root_page.status) unless root_page.success?
 

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -31,7 +31,7 @@ module Checks
     private
 
     def analyze!
-      raise DnsResolutionError.new(audit.url) unless Browser.resolvable?(audit.url)
+      raise DnsResolutionError.new(audit.url) unless Dns.resolvable?(audit.url)
       raise BrowserError.new(audit.url) if root_page.status.nil?
       raise UnreachableSiteError.new(audit.url, root_page.status) unless root_page.success?
 

--- a/app/models/crawler.rb
+++ b/app/models/crawler.rb
@@ -1,6 +1,6 @@
 class Crawler
   include Enumerable
-  MAX_CRAWLED_PAGES = 20
+  MAX_CRAWLED_PAGES = 5
 
   class NoMatchError < StandardError
     def initialize(root, crawled, &block)

--- a/db/migrate/20250822083059_remove_retry_count_from_checks.rb
+++ b/db/migrate/20250822083059_remove_retry_count_from_checks.rb
@@ -1,0 +1,5 @@
+class RemoveRetryCountFromChecks < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :checks, :retry_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_134440) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_22_083059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,7 +47,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_11_134440) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "priority", default: 100, null: false
-    t.integer "retry_count", default: 0, null: false
     t.index ["audit_id"], name: "index_checks_on_audit_id"
   end
 

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RunCheckJob do
       allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
         .to receive(:analyze!) do
           original_error = StandardError.new("Original cause error")
-          raise Check::NonRetryableError, "Wrapper error", cause: original_error
+          raise Check::PermanentError, "Wrapper error", cause: original_error
         end
     end
 
@@ -76,8 +76,8 @@ RSpec.describe RunCheckJob do
 
       expect(check.error)
         .to include(
-          "json_class" => "Check::NonRetryableError",
-          "m" => "Wrapper error"
+          "json_class" => "StandardError",
+          "m" => "Original cause error"
         )
     end
   end

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe RunCheckJob do
   let(:check) { create(:check, :accessibility_mention, :ready) }
 
-  context "when the check goes well" do
+  context "when check.run! doesn't raise" do
     before do
       # Sure, the any_instance_of is sad but there is no other way:
       # since ActiveJob deserializes models with GlobalID, mocking the
@@ -23,13 +23,72 @@ RSpec.describe RunCheckJob do
     end
   end
 
-  context "when the check does not go well" do
+  context "when check.run! raises a PermanentError (DNS error)" do
+    before do
+      allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
+        .to receive(:analyze!).and_raise Checks::Reachable::DnsResolutionError.new("https://test.com")
+    end
+
+    it "transitions the check to failed immediately" do
+      perform_enqueued_jobs do
+        expect { described_class.perform_later(check) }
+          .to change(check, :current_state)
+                .from("ready")
+                .to("failed")
+      end
+    end
+
+    it "stores the original error in the transition metadata" do
+      perform_enqueued_jobs do
+        described_class.perform_later(check)
+      end
+
+      expect(check.error)
+        .to include(
+          "json_class" => "Checks::Reachable::DnsResolutionError",
+          "m" => "DNS resolution failed for https://test.com"
+        )
+    end
+  end
+
+  context "when check.run! raises a PermanentError (crawler error)" do
+    before do
+      allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
+        .to receive(:analyze!) do
+          original_error = StandardError.new("Original cause error")
+          raise Check::NonRetryableError, "Wrapper error", cause: original_error
+        end
+    end
+
+    it "transitions the check to failed immediately" do
+      perform_enqueued_jobs do
+        expect { described_class.perform_later(check) }
+          .to change(check, :current_state)
+                .from("ready")
+                .to("failed")
+      end
+    end
+
+    it "stores the original cause error in the transition metadata" do
+      perform_enqueued_jobs do
+        described_class.perform_later(check)
+      end
+
+      expect(check.error)
+        .to include(
+          "json_class" => "Check::NonRetryableError",
+          "m" => "Wrapper error"
+        )
+    end
+  end
+
+  context "when check.run! raises a retryable error" do
     before do
       allow_any_instance_of(check.class) # rubocop:disable RSpec/AnyInstance
         .to receive(:analyze!).and_raise Ferrum::TimeoutError.new("Test error")
     end
 
-    it "transitions the check to failed" do
+    it "transitions the check to failed after retries" do
       perform_enqueued_jobs do
         expect { described_class.perform_later(check) }
           .to change(check, :current_state)

--- a/spec/libs/dns_spec.rb
+++ b/spec/libs/dns_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Dns do
+  describe ".resolvable?" do
+    subject(:resolvable) { described_class.resolvable?(url) }
+
+    let(:url) { "https://example.com/" }
+    let(:dns) { instance_double(Resolv::DNS) }
+
+    before do
+      allow(Resolv::DNS).to receive(:new).and_return(dns)
+    end
+
+    context "with a resolvable domain" do
+      it "returns true" do
+        allow(dns).to receive(:getaddress).and_return("1.2.3.4")
+        expect(resolvable).to be(true)
+      end
+    end
+
+    context "with an invalid URL" do
+      let(:url) { "invalid-url" }
+
+      it "returns false" do
+        expect(resolvable).to be(false)
+      end
+    end
+
+    context "with a non-resolvable domain" do
+      it "returns false when DNS resolution fails" do
+        allow(dns).to receive(:getaddress).and_raise(Resolv::ResolvError)
+
+        expect(resolvable).to be(false)
+      end
+
+      it "returns false when DNS lookup times out" do
+        allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+
+        expect(resolvable).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/browser_spec.rb
+++ b/spec/models/browser_spec.rb
@@ -145,44 +145,6 @@ RSpec.describe Browser do
     end
   end
 
-  describe "#resolvable?" do
-    subject(:resolvable) { instance.resolvable?(url) }
-
-    let(:dns) { instance_double(Resolv::DNS) }
-
-    before do
-      allow(Resolv::DNS).to receive(:new).and_return(dns)
-    end
-
-    context "with a resolvable domain" do
-      it "returns true" do
-        allow(dns).to receive(:getaddress).and_return("1.2.3.4")
-        expect(resolvable).to be(true)
-      end
-    end
-
-    context "with an invalid URL" do
-      let(:url) { "invalid-url" }
-
-      it "returns false" do
-        expect(resolvable).to be(false)
-      end
-    end
-
-    context "with a non-resolvable domain" do
-      it "returns false when DNS resolution fails" do
-        allow(dns).to receive(:getaddress).and_raise(Resolv::ResolvError)
-
-        expect(resolvable).to be(false)
-      end
-
-      it "returns false when DNS lookup times out" do
-        allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
-
-        expect(resolvable).to be(false)
-      end
-    end
-  end
 
   describe "#browser" do
     let(:ferrum_browser) { instance_double(Ferrum::Browser) }

--- a/spec/models/browser_spec.rb
+++ b/spec/models/browser_spec.rb
@@ -145,6 +145,45 @@ RSpec.describe Browser do
     end
   end
 
+  describe "#resolvable?" do
+    subject(:resolvable) { instance.resolvable?(url) }
+
+    let(:dns) { instance_double(Resolv::DNS) }
+
+    before do
+      allow(Resolv::DNS).to receive(:new).and_return(dns)
+    end
+
+    context "with a resolvable domain" do
+      it "returns true" do
+        allow(dns).to receive(:getaddress).and_return("1.2.3.4")
+        expect(resolvable).to be(true)
+      end
+    end
+
+    context "with an invalid URL" do
+      let(:url) { "invalid-url" }
+
+      it "returns false" do
+        expect(resolvable).to be(false)
+      end
+    end
+
+    context "with a non-resolvable domain" do
+      it "returns false when DNS resolution fails" do
+        allow(dns).to receive(:getaddress).and_raise(Resolv::ResolvError)
+
+        expect(resolvable).to be(false)
+      end
+
+      it "returns false when DNS lookup times out" do
+        allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+
+        expect(resolvable).to be(false)
+      end
+    end
+  end
+
   describe "#browser" do
     let(:ferrum_browser) { instance_double(Ferrum::Browser) }
     let(:network) { instance_double(Ferrum::Network) }

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -68,14 +68,26 @@ RSpec.describe Check do
       end
     end
 
-    context "when analyze! raises an error" do
+    context "when analyze! raises a PermanentError" do
+      let(:error) { Check::PermanentError.new("DNS resolution failed") }
+
+      before do
+        allow(check).to receive(:analyze!).and_raise(error)
+      end
+
+      it "re-raises the PermanentError unchanged" do
+        expect { check.run! }.to raise_error(Check::PermanentError, "DNS resolution failed")
+      end
+    end
+
+    context "when analyze! raises any other error" do
       let(:error) { Ferrum::TimeoutError.new("Test error") }
 
       before do
         allow(check).to receive(:analyze!).and_raise(error)
       end
 
-      it "raises a Check::RuntimeError with the correct root cause" do
+      it "wraps it in a Check::RuntimeError with the correct root cause" do
         expect { check.run! }.to raise_error(Check::RuntimeError) do |err|
           expect(err.cause).to eq error
         end

--- a/spec/models/checks/find_accessibility_page_spec.rb
+++ b/spec/models/checks/find_accessibility_page_spec.rb
@@ -108,17 +108,17 @@ RSpec.describe Checks::FindAccessibilityPage do
           allow(crawler).to receive(:find).and_raise(mock_error_class.new("Test error"))
         end
 
-        it "raises NonRetryableError" do
+        it "raises PermanentError" do
           expect {
             check.send(:find_page)
-          }.to raise_error(Check::NonRetryableError)
+          }.to raise_error(Check::PermanentError)
         end
 
         it "preserves the original exception as cause" do
           expect {
             check.send(:find_page)
           }.to raise_error do |error|
-            expect(error).to be_a(Check::NonRetryableError)
+            expect(error).to be_a(Check::PermanentError)
             expect(error.cause).to be_a(mock_error_class)
             expect(error.cause.message).to eq("Test error")
           end

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Checks::Reachable do
 
   before do
     allow(check).to receive_messages(audit:, root_page:, site:)
+    # Mock DNS resolution to return true by default for existing tests
+    allow(Browser).to receive(:resolvable?).and_return(true)
   end
 
   describe "constants" do
@@ -107,6 +109,18 @@ RSpec.describe Checks::Reachable do
             check.send(:analyze!)
           }.to raise_error(Checks::Reachable::BrowserError, "Browser error preventing getting #{original_url}")
         end
+      end
+    end
+
+    context "when DNS resolution fails" do
+      before do
+        allow(Browser).to receive(:resolvable?).and_return(false)
+      end
+
+      it "raises a DnsResolutionError" do
+        expect {
+          check.send(:analyze!)
+        }.to raise_error(Checks::Reachable::DnsResolutionError, "DNS resolution failed for #{original_url}")
       end
     end
   end

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Checks::Reachable do
   before do
     allow(check).to receive_messages(audit:, root_page:, site:)
     # Mock DNS resolution to return true by default for existing tests
-    allow(Browser).to receive(:resolvable?).and_return(true)
+    allow(Dns).to receive(:resolvable?).and_return(true)
   end
 
   describe "constants" do
@@ -114,7 +114,7 @@ RSpec.describe Checks::Reachable do
 
     context "when DNS resolution fails" do
       before do
-        allow(Browser).to receive(:resolvable?).and_return(false)
+        allow(Dns).to receive(:resolvable?).and_return(false)
       end
 
       it "raises a DnsResolutionError" do


### PR DESCRIPTION
- Add PermanentError and NonRetryableError exceptions to Check namespace
- Handle NonRetryableErrors in Check
- Don't retry NonRetryableErrors in RunCheckJob
- Move MAX_RETRIES to RunCheckJob
- Remove checks.retry_count column because retry_on… attempts: supersedes it
- Raise a permanent DNS resolution error when a hostname doesn't exist to prevent Reachable from spending 4 minutes in vain
- Reduce crawled pages from 20 to 5 to fail faster on sites without a declaration

Fixes #195
Fixes #213