### PR TITLE
fix: Prevent simultaneous jobs from changing the same check

### DIFF
--- a/app/jobs/process_audit_job.rb
+++ b/app/jobs/process_audit_job.rb
@@ -4,12 +4,10 @@
 # harmless.
 class ProcessAuditJob < ApplicationJob
   def perform(audit)
-    ready_check_jobs = audit
-                       .checks
-                       .remaining
-                       .filter { |check| check.transition_to(:ready) }
-                       .map { |check| RunCheckJob.new(check) }
-
-    ActiveJob.perform_all_later(ready_check_jobs)
+    audit
+      .checks
+      .remaining
+      .filter { |check| check.transition_to(:ready) }
+      .each { |check| RunCheckJob.set(group: "check_#{check.id}").perform_later(check) }
   end
 end


### PR DESCRIPTION
Should fix Sentry error:

> PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_check_transitions_parent_sort" (ActionView::Template::Error)
DETAIL:  Key (check_id, sort_key)=(6497, 10) already exists.