### PR TITLE
fix: Add aborted state for checks that could not run

### DIFF
--- a/app/helpers/check_helper.rb
+++ b/app/helpers/check_helper.rb
@@ -9,6 +9,7 @@ module CheckHelper
     running:   :new,
     completed: :success,
     failed:    :error,
+    aborted:   :error,
   }
 
   def status_to_badge_text(check)

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -81,6 +81,6 @@ class Audit < ApplicationRecord
     checks
       .remaining
       .filter { |other_check| other_check.depends_on?(check.to_requirement) }
-      .each   { |other_check| other_check.transition_to!(:failed) }
+      .each   { |other_check| other_check.transition_to!(:aborted) }
   end
 end

--- a/app/models/check_state_machine.rb
+++ b/app/models/check_state_machine.rb
@@ -9,11 +9,12 @@ class CheckStateMachine
   state :running
   state :failed
   state :completed
+  state :aborted
 
-  transition from: :pending, to: [:ready, :blocked, :failed]
+  transition from: :pending, to: [:ready, :blocked, :aborted]
   transition from: :ready,   to: [:running]
   transition from: :running, to: [:failed, :completed]
-  transition from: :blocked, to: [:ready]
+  transition from: :blocked, to: [:ready, :aborted]
 
   guard_transition(to: :ready) do |check|
     check.all_requirements_met?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -116,6 +116,7 @@ fr:
         running: En cours
         failed: Échoué
         completed: Effectué
+        aborted: Annulé
       checks/accessibility_mention:
         type: Mention du niveau d'accessibilité
         table_header: Mention

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Audit do
     it "aborts any check that depends on the failed one" do
       expect { audit.abort_dependent_checks!(original_check) }
         .to change(dependent_check, :current_state)
-              .from("pending").to("failed")
+              .from("pending").to("aborted")
     end
   end
 end


### PR DESCRIPTION
L'état "échoué" est désormais réservé pour les contrôles qui ont échoué, ceux qui n'ont pas pu tourner sont basculés sur l'état "annulé". Corrige un problème de transition interdite.