### PR TITLE
fix: Adjust expected headings when the declaration page isn't shown

### DIFF
--- a/app/views/checks/_accessibility_page_heading.html.erb
+++ b/app/views/checks/_accessibility_page_heading.html.erb
@@ -31,7 +31,7 @@
         </li>
       <% end %>
     <% else %>
-      <% check.expected_headings.each do |level, heading| %>
+      <% Checks::AccessibilityPageHeading::EXPECTED_HEADINGS.each do |level, heading| %>
         <li class="fr-mb-2w">
           <strong>
             <code>&lt;h<%= level %>&gt;</code>


### PR DESCRIPTION
Missed rename in 1d70e42a74901ee0f8d8260b2c2f86c84083ecab