### PR TITLE
fix: Prevent Check state machine from raising during race conditions

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -7,12 +7,14 @@ class Check < ApplicationRecord
           ]
 
   def state_machine
-    @state_machine || CheckStateMachine.new(
-      self,
-      transition_class: CheckTransition,
-      association_name: :check_transitions,
-      initial_transition: true
-    )
+    Statesman::Machine.retry_conflicts do
+      CheckStateMachine.new(
+        self,
+        transition_class: CheckTransition,
+        association_name: :check_transitions,
+        initial_transition: true
+      )
+    end
   end
 
   delegate :current_state,


### PR DESCRIPTION
Calling StateMachine.new with initial_transition: true tries to create a transition immediately. So when two processes query a check's state simultaneously, both try to create an initial transition, and then 💥 