### PR TITLE
chore: Remove bundle warnings when running bin/cucumber

### DIFF
--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'bundler/setup' if File.exist?("Gemfile")
+
 vendored_cucumber_bin = Dir["#{File.dirname(__FILE__)}/../vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
 if vendored_cucumber_bin
   load File.expand_path(vendored_cucumber_bin)


### PR DESCRIPTION
Pour ne plus avoir besoin de taper `bundle exec bin/cucumber` (les scripts dans `bin/` sont sensés prendre le setup du projet en compte).