### PR TITLE
fix: Add debug port to jobs docker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
     command: "bin/jobs"
     ports: []
     environment:
-      RUBY_DEBUG_PORT: ''
+      DATABASE_URL: 'postgresql://postgres:dummy@db:5433'
+      RUBY_DEBUG_PORT: 3500
+      RUBY_DEBUG_PORT_RANGE: 10
   db:
     image: postgres
     environment:


### PR DESCRIPTION
- solid_queue and debug gem are not being friendly with each other
- the debug port and the range fixes the issue of the service not starting
https://github.com/rails/solid_queue/issues/572