### PR TITLE
refactor: Improve authentication management

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -34,7 +34,7 @@ module Authentication
   end
 
   def find_session_by_cookie
-    Session.find(cookies.signed[:session_id]) if cookies.signed[:session_id]
+    Session.active.find(cookies.signed[:session_id]) if cookies.signed[:session_id]
   rescue ActiveRecord::RecordNotFound
     cookies.delete(:session_id)
     nil

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -46,7 +46,7 @@ module Authentication
   end
 
   def after_authentication_url
-    session.delete(:return_to_after_authenticating) || root_url
+    session.delete(:return_to_after_authenticating) || authenticated_root_url
   end
 
   def start_new_session_for(user)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,7 +30,7 @@ module Authentication
   end
 
   def resume_session
-    Current.session ||= find_session_by_cookie
+    Current.session ||= find_session_by_cookie&.tap(&:touch)
   end
 
   def find_session_by_cookie

--- a/app/jobs/remove_inactive_sessions_job.rb
+++ b/app/jobs/remove_inactive_sessions_job.rb
@@ -1,0 +1,5 @@
+class RemoveInactiveSessionsJob < ApplicationJob
+  def perform
+    Session.inactive.delete_all
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -4,4 +4,5 @@ class Session < ApplicationRecord
   belongs_to :user, touch: true
 
   scope :active, -> { where(updated_at: MAX_IDLE_TIME.ago..) }
+  scope :inactive, -> { where(updated_at: ...MAX_IDLE_TIME.ago) }
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,3 +1,7 @@
 class Session < ApplicationRecord
+  MAX_IDLE_TIME = 1.month
+
   belongs_to :user, touch: true
+
+  scope :active, -> { where(updated_at: MAX_IDLE_TIME.ago..) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,13 @@
 class User < ApplicationRecord
+  MAX_IDLE_TIME = 18.months
+
   belongs_to :team, foreign_key: :siret, primary_key: :siret, inverse_of: :users, touch: true
   has_many :sites, through: :team
   has_many :sessions, dependent: :destroy
 
   scope :logged_in, -> { joins(:sessions) }
   scope :logged_out, -> { where.missing(:sessions) }
-  scope :inactive, -> do
-    with(inactive_users: [
-      logged_out.where(updated_at: ..1.year.ago),
-      logged_in.where(sessions: { created_at: ..18.months.ago })
-    ]).from("inactive_users")
-  end
+  scope :inactive, -> { where(updated_at: ...MAX_IDLE_TIME.ago) }
 
   validates :provider, :uid, :email, :name, :siret, presence: true
   validates :uid, uniqueness: { scope: :provider, if: :uid_changed? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  MAX_IDLE_TIME = 18.months
+  MAX_IDLE_TIME = 1.year
 
   belongs_to :team, foreign_key: :siret, primary_key: :siret, inverse_of: :users, touch: true
   has_many :sites, through: :team

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -7,6 +7,10 @@ production:
     class: RemoveInactiveUsersJob
     queue: background
     schedule: every month at 1am
+  remove_inactive_sessions:
+    class: RemoveInactiveSessionsJob
+    queue: background
+    schedule: every day at 1am
   remove_inactive_teams:
     class: RemoveInactiveTeamsJob
     queue: background

--- a/spec/jobs/remove_inactive_sessions_job_spec.rb
+++ b/spec/jobs/remove_inactive_sessions_job_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe RemoveInactiveSessionsJob do
+  describe "#perform" do
+    let!(:user) { create(:user) }
+    let!(:active_session) { create(:session, user:, updated_at: 1.minute.ago) }
+    let!(:inactive_session) { create(:session, user:, updated_at: Session::MAX_IDLE_TIME.ago - 1.day) }
+
+    it "destroys inactive sessions" do
+      expect { described_class.perform_now }.to change(Session, :count).by(-1)
+      expect(Session.all).to contain_exactly(active_session)
+    end
+
+    it "does not update users when removing their inactive sessions" do
+      expect { described_class.perform_now }.not_to change { user.reload.updated_at }
+    end
+
+    context "when there are no inactive sessions" do
+      it "does nothing" do
+        Session.inactive.delete_all
+
+        expect { described_class.perform_now }.not_to change(Session, :count)
+      end
+    end
+  end
+end

--- a/spec/jobs/remove_inactive_users_job_spec.rb
+++ b/spec/jobs/remove_inactive_users_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe RemoveInactiveUsersJob do
+  describe "#perform" do
+    let!(:team) { create(:team) }
+    let!(:active_user) { create(:user, team:) }
+    let!(:inactive_user) { create(:user, team:, updated_at: User::MAX_IDLE_TIME.ago - 1.day) }
+
+    it "destroys inactive users" do
+      expect { described_class.perform_now }.to change(User, :count).by(-1)
+      expect(User.all).to contain_exactly(active_user)
+    end
+
+    context "when there are no inactive users" do
+      it "does not destroy any users" do
+        User.update_all(updated_at: 1.minute.ago)
+
+        expect { described_class.perform_now }.not_to change(User, :count)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe User do
     end
   end
 
+  describe "scopes" do
+    describe ".inactive" do
+      it "returns users not updated in 18 months" do
+        active_user = create(:user, updated_at: 1.minute.ago)
+        inactive_user = create(:user, updated_at: described_class::MAX_IDLE_TIME.ago - 1.day)
+
+        expect(described_class.inactive).to include(inactive_user)
+        expect(described_class.inactive).not_to include(active_user)
+      end
+    end
+  end
+
   describe ".from_omniauth" do
     subject(:from_omniauth) { described_class.from_omniauth(auth) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe User do
     end
 
     describe ".inactive" do
-      it "returns users not updated in 18 months" do
+      it "returns users not updated in a year" do
         active_user = create(:user, updated_at: 1.minute.ago)
         inactive_user = create(:user, updated_at: described_class::MAX_IDLE_TIME.ago - 1.day)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe User do
   end
 
   describe "scopes" do
+    describe ".logged_in" do
+      it "returns users with sessions" do
+        user_with_session = create(:user)
+        create(:session, user: user_with_session)
+        user_without_session = create(:user)
+
+        expect(described_class.logged_in).to include(user_with_session)
+        expect(described_class.logged_in).not_to include(user_without_session)
+      end
+    end
+
+    describe ".logged_out" do
+      it "returns users without sessions" do
+        user_with_session = create(:user)
+        create(:session, user: user_with_session)
+        user_without_session = create(:user)
+
+        expect(described_class.logged_out).to include(user_without_session)
+        expect(described_class.logged_out).not_to include(user_with_session)
+      end
+    end
+
     describe ".inactive" do
       it "returns users not updated in 18 months" do
         active_user = create(:user, updated_at: 1.minute.ago)

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "Authentication" do
+  let(:user) { create(:user) }
+
+  describe "login" do
+    subject(:login) { feature_login_as(user) }
+
+    it "creates a session and redirects to authenticated_root" do
+      expect { login }.to change(Session, :count).by(1)
+      expect(response).to redirect_to(authenticated_root_path)
+    end
+  end
+
+  describe "when browsing" do
+    subject(:get_authenticated_root) { get authenticated_root_path }
+
+    context "with no session" do
+      it "redirects to login page" do
+        get_authenticated_root
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context "with an active session" do
+      before { feature_login_as(user) }
+
+      it "allows access and touches the session" do
+        session = user.sessions.last
+        session.update_columns(updated_at: 1.day.ago)
+        get_authenticated_root
+        expect(response).to have_http_status(:success)
+        expect(session.reload.updated_at).to be_within(1.minute).of(Time.current)
+      end
+    end
+
+    context "with an expired session" do
+      it "redirects to login page" do
+        updated_at = Session::MAX_IDLE_TIME.ago + 1.day
+        expired_session = create(:session, user:, updated_at:)
+        allow_any_instance_of(Authentication).to receive(:find_session_by_cookie).and_return(nil) # rubocop:disable RSpec/AnyInstance
+
+        get_authenticated_root
+        expect(response).to redirect_to(login_path)
+      end
+    end
+  end
+
+  describe "logout" do
+    before { login_as(user) }
+
+    it "destroys the session and redirects to login" do
+      expect { delete logout_path }.to change(Session, :count).by(-1)
+      expect(response).to redirect_to(login_path)
+    end
+  end
+end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -20,7 +20,7 @@ module AuthHelpers
       }
     )
 
-    visit "/auth/developer"
+    get "/auth/developer/callback"
   end
 end
 

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -8,11 +8,15 @@ module AuthHelpers
   def feature_login_as(user)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:developer] = OmniAuth::AuthHash.new(
-      provider: "developer",
-      uid: user.email,
+      provider: user.provider,
+      uid: user.uid,
       info: {
         email: user.email,
-        name: user.name
+        name: user.name,
+        organizational_unit: user.team.organizational_unit
+      },
+      extra: {
+        raw_info: { siret: user.team.siret }
       }
     )
 


### PR DESCRIPTION
- [x] Redirect to authenticated_root after login
- [x] Touch sessions on login
- [x] Expire sessions after 1 month of inactivity
- [x] Exclude and delete inactive sessions automatically
- [x] Add specs for authentication flow