### PR TITLE
fix: Fix developer omniauth login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   class << self
     def from_omniauth(auth)
       data_source = auth.info
-      siret = auth.extra.raw_info.siret
+      siret = auth.provider == "developer" ? data_source.siret : auth.extra.raw_info.siret
 
       user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
       user.assign_attributes(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,6 +51,38 @@ RSpec.describe User do
       )
     end
 
+    context 'when in development environment' do
+      let(:auth) do
+        OmniAuth::AuthHash.new(
+          {
+            provider: "developer",
+            uid: "123",
+            info: {
+              email:,
+              organizational_unit:,
+              name: "Yan Zhu",
+              siret:
+            }
+          }
+        )
+      end
+
+      context "when user does not exist" do
+        it "creates a new user with the provided attributes" do
+          expect { from_omniauth }.to change(described_class, :count).by(1)
+
+          user = described_class.last
+          expect(user).to have_attributes(
+                            siret:,
+                            provider: auth.provider,
+                            uid: auth.uid,
+                            email: auth.info.email,
+                            name: "Yan Zhu",
+                          )
+        end
+      end
+    end
+
     context "when user does not exist" do
       it "creates a new user with the provided attributes" do
         expect { from_omniauth }.to change(described_class, :count).by(1)


### PR DESCRIPTION
- In dev env, we need to use auth.info instead of auth.extra.raw_info in from_omniauth method
- The siret is present in auth.info