### PR TITLE
fix: Add concurrency limits to RunCheckJob

### DIFF
--- a/app/jobs/run_check_job.rb
+++ b/app/jobs/run_check_job.rb
@@ -1,6 +1,8 @@
 require "json/add/exception" # required to serialize errors as JSON
 
 class RunCheckJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(check) { check.audit_id }
+
   rescue_from Check::RuntimeError do |exception|
     cleaned_exception = exception.cause.dup
     cleaned_exception.set_backtrace Rails.backtrace_cleaner.clean(exception.cause.backtrace)


### PR DESCRIPTION
Limit RunCheckJob concurrency to 1 per audit to prevent resource conflicts