### PR TITLE
fix: Ignore double slash in URL path

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -24,6 +24,7 @@ Link = Data.define(:href, :text) do
       return uri if uri.relative?
 
       path = uri.path
+      path = path.gsub("//", "/")
       unless path == "/"
         path = File.expand_path(uri.path, "/")
         path = path[1..-1] if path.start_with?("/")

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Link do
       expect(normalized.to_s).to include("?param=value")
     end
 
+    it "normalizes paths with doubled slashes" do
+      normalized = described_class.normalize("http://example.com/folder//")
+      expect(normalized.to_s).to eq("http://example.com/folder/")
+    end
+
     it "normalizes paths with parent directory references" do
       normalized = described_class.normalize("http://example.com/folder/../page.html")
       expect(normalized.to_s).to eq("http://example.com/page.html")


### PR DESCRIPTION
Fixes `https://www.strasbourg.fr/` redirecting to `https://www.strasbourg.eu//`