### PR TITLE
feat: Add tag filtering to site index

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -7,6 +7,7 @@ class SitesController < ApplicationController
   def index
     params[:sort] ||= { checked_at: :desc }
     sites = current_user.sites.preloaded.filter_by(params).order_by(params)
+    @tags = current_user.team.tags.in_alphabetical_order
     respond_to do |format|
       format.html { @pagy, @sites = pagy sites, limit: pagy_limit }
       format.csv { send_data sites.to_csv, filename: sites.to_csv_filename }

--- a/app/queries/site_query.rb
+++ b/app/queries/site_query.rb
@@ -26,6 +26,9 @@ class SiteQuery < SimpleDelegator
       case key.to_sym
       when :q
         scope = scope.joins(:audits).where("sites.name ILIKE :term OR audits.url ILIKE :term", term: "%#{value}%")
+      when :tag_id
+        scope = scope.joins(:site_tags)
+                     .where(site_tags: { tag_id: value })
       end
     end
     scope

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (label:, attribute:, options:, include_blank:, params_key:) %>
+
+<%= form_with(url: url_for, method: :get) do |f| %>
+  <% (params[params_key] || {}).except(attribute).compact_blank.each do |key, value| %>
+    <%= f.hidden_field key, value:, name: "#{params_key}[#{key}]", id: nil %>
+  <% end %>
+  <div class="fr-grid-row fr-grid-row--gutters">
+    <div class="fr-col">
+      <div class="fr-row">
+        <%= f.dsfr_label_with_hint attribute, label:, for: attribute, class: "fr-sr-only" %>
+      </div>
+      <div class="fr-row">
+        <%= f.dsfr_select_tag attribute, options, include_blank:, selected: params.dig(params_key, attribute), name: "#{params_key}[#{attribute}]" %>
+      </div>
+    </div>
+    <div class="fr-col">
+      <%= f.submit t("shared.filter"), class: "fr-btn fr-btn--secondary" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -7,12 +7,8 @@
   <% end %>
   <td class="fr-cell--multiline">
     <% tags = site.tags.collect(&:name) %>
-    <% if tags.any? %>
-      <%= safe_join site.tags.take(3).collect(&:name).map { dsfr_tag(title: it.truncate(35), size: :sm) } %>
-      <%= dsfr_tooltip(t("shared.x_more", x: tags.size - 3), type: :link, title: site.tags[3..].collect(&:name).to_sentence) if tags.size > 3 %>
-    <% else %>
-      N/A
-    <% end %>
+    <%= safe_join tags.take(3).map { dsfr_tag(title: it.truncate(35), size: :sm) } %>
+    <%= dsfr_tooltip(t("shared.x_more", x: tags.size - 3), type: :link, title: tags[3..].to_sentence) if tags.size > 3 %>
   </td>
   <td>
     <% checked_at = site.audit.checked_at || site.audit.updated_at %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,5 +1,14 @@
 <%= turbo_stream_from :sites %>
 
+<div class="fr-col-6">
+  <%= render "shared/filter",
+             attribute: :tag_id,
+             label: Tag.human(:filter),
+             params_key: :search,
+             include_blank: Tag.human(:all),
+             options: options_from_collection_for_select(@tags, :id, :name, params.dig(:search, :tag_id)) %>
+</div>
+
 <% form_id = :table_form %>
 <%= form_with(url: sites_path, method: :delete, id: form_id) {} %><%# Form inputs are in every line, associated with the form id %>
 <%= dsfr_table(caption: Site.human(:all), border: true) do |t| %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -12,6 +12,7 @@ fr:
     apply: Appliquer
     applying: Appliquer…
     add: Ajouter
+    filter: Filtrer
     send: Envoyer
     save: Enregistrer
     saving: Enregistrement…
@@ -223,13 +224,14 @@ fr:
           one: Un site
           other: "%{count} sites"
       tag:
-        all: Étiquettes
+        all: Toutes les étiquettes
         name: Libellé
         new: Nouvelle étiquette
         add: Créer une nouvelle étiquette
         sites: Sites
         delete: Supprimer cette étiquette
         edit: Modifier cette étiquette
+        filter: Filtrer par étiquette
         count:
           zero: Aucune étiquette
           one: Une étiquette

--- a/features/page_des_sites.feature
+++ b/features/page_des_sites.feature
@@ -7,6 +7,21 @@ Fonctionnalité:
     Et que je me pro-connecte
     Et que je clique sur "Ajouter un site"
 
+  Scénario: Un agent peut filtrer les sites par nom de tag
+    Sachant que je possède un fichier "tmp/sites.csv" qui contient
+      """
+      url;tags
+      https://beta.gouv.fr;beta
+      https://numerique.gouv.fr;gouv,public
+      https://www.suresnes.fr;public
+      """
+    Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
+    Quand je clique sur "Importer"
+    Et que je filtre par étiquette "public"
+    Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
+      | suresnes.fr       |
+      | numerique.gouv.fr |
+
   Scénario: Un agent peut trier les sites par URL croissantes
     Sachant que je possède un fichier "tmp/sites.csv" qui contient
       """

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -3,3 +3,10 @@
 Quand("je possède un fichier {string} qui contient") do |path, content|
   File.write(path, content)
 end
+
+Quand("je filtre par étiquette {string}") do |tag|
+  steps %(
+    Quand je sélectionne "#{tag}" pour "Filtrer par étiquette"
+    Et que je clique sur "Filtrer"
+  )
+end

--- a/spec/queries/site_query_spec.rb
+++ b/spec/queries/site_query_spec.rb
@@ -91,15 +91,27 @@ RSpec.describe SiteQuery do
   describe "#filter_by" do
     subject(:result) { query.filter_by(params) }
 
-    let(:request) { { search: { q: "bar" } } }
+    let(:tag) { create(:tag) }
+    let(:another_tag) { create(:tag) }
+    let!(:no_match) { create(:site, :checked, url: "https://foo.com/") }
+    let!(:domain_match) { create(:site, :checked, url: "https://www.bar.com/", tags: [tag]) }
+    let!(:path_match) { create(:site, :checked, url: "https://baz.com/bar/", tags: [tag, another_tag]) }
+    let!(:name_match) { create(:site, :checked, url: "https://www.apple.com/", name: "Foo Bar Baz") }
 
-    it "returns only sites matching the query" do
-      no_match = create(:site, :checked, url: "https://foo.com/")
-      domain_match = create(:site, :checked, url: "https://www.bar.com/")
-      path_match = create(:site, :checked, url: "https://baz.com/bar/")
-      name_match = create(:site, :checked, url: "https://www.apple.com/", name: "Foo Bar Baz")
+    context 'when filtering by site name or url' do
+      let(:request) { { search: { q: "bar" } } }
 
-      expect(result.to_a).to contain_exactly(domain_match, path_match, name_match)
+      it "returns only sites matching the query" do
+        expect(result.to_a).to contain_exactly(domain_match, path_match, name_match)
+      end
+    end
+
+    context 'when filtering by a tag' do
+      let(:request) { { search: { tag_id: "#{tag.id}" } } }
+
+      it "returns only sites matching the query" do
+        expect(result.to_a).to contain_exactly(domain_match, path_match)
+      end
     end
   end
 


### PR DESCRIPTION
- Update `SiteQuery` to support filtering by tag using `tag_id`
- Add a tag filter dropdown to the site index view
- Load tags in `SitesController` for filtering options