### PR TITLE
feat: Configure SolidQueue to actually clear finished jobs

### DIFF
--- a/config/initializers/solid_queue.rb
+++ b/config/initializers/solid_queue.rb
@@ -1,4 +1,0 @@
-Rails.application.config.solid_queue.configure do |config|
-  config.delete_finished_jobs_after = 2.days
-  config.cleanup_interval = 6.hours
-end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,4 +1,8 @@
 production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    queue: background
+    schedule: every day at 7:00 and 21:00
   remove_orphan_tags:
     class: RemoveOrphanTagsJob
     queue: background


### PR DESCRIPTION
`config.delete_finished_jobs_after` defaults to `1.day` BUT doesn't do anything on its own!

[The installer started including this job](https://github.com/rails/solid_queue/commit/6437617966bc5bf92995986fc1b14e00f8c68848) _after_ SolidQueue had been added to the application, so it was never added, and finished jobs kept piling up long after they were supposed to be removed. 