### PR TITLE
feat: Make environments visually distinct

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -165,6 +165,25 @@ form.button_to {
   margin-bottom: 0;
 }
 
+// Add visual distinction for dev & staging environments
+.fr-header {
+  &.staging::before,
+  &.development::before {
+    display: block;
+    text-align: center;
+    font-weight: bold;
+    padding: .5em;
+  }
+  &.staging::before {
+    content: "Environnement de staging";
+    background-color: orange;
+  }
+  &.development::before {
+    content: "Environnement de développement";
+    background-color: #87ec87;
+  }
+}
+
 // Fix vertical alignment of search and counter on narrow screens
 @media (max-width: 47.999em) {
   .fr-search-bar + .fr-table__detail {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,8 @@
   title: t("global.service_name"),
   tagline: t("global.service_description"),
   html_attributes: {
-    id: :nav
+    id: :nav,
+    class: class_names(development: Rails.env.development?, staging: Rails.application.staging?)
   }) do |header| %>
   <%= header.with_direct_link_simple title: t("pages.accueil.title"), path: root_path, active: current_page?(root_path) %>
 


### PR DESCRIPTION
Add a distinct banner on staging and development apps to distinguish them from production.

## Staging

<img width="788" height="530" alt="Staging banner" src="https://github.com/user-attachments/assets/17cb3b74-ba27-4433-a700-a7da8e715370" />

## Development
<img width="786" height="520" alt="Development banner" src="https://github.com/user-attachments/assets/dbd99386-c41c-4712-abaa-3dee69d05a5d" />
