### PR TITLE
fix: Adjust allowed format for accessibility mention

### DIFF
--- a/app/models/checks/accessibility_mention.rb
+++ b/app/models/checks/accessibility_mention.rb
@@ -3,10 +3,9 @@ module Checks
     PRIORITY = 10
     MENTION_REGEX = /accessibilit[ée]     # Match "accessibilité" or "accessibilite"
                     \s*                   # Optional whitespace
-                    (?:\w+\s+){0,3}       # Optional words (up to 3)
                     :?                    # Optional colon
                     \s*                   # Optional whitespace
-                    (?:\w+\s+){0,3}       # Optional words (up to 3)
+                    \(?                   # Optional open parenthesis
                     (?<level>non|partiellement|totalement)  # Capture the level
                     \s+                   # Required whitespace
                     conforme              # Match "conforme"

--- a/spec/models/checks/accessibility_mention_spec.rb
+++ b/spec/models/checks/accessibility_mention_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe Checks::AccessibilityMention do
       "" => nil,
       "ACCESSIBILITE : NON CONFORME" => "non",
       "Accessibilité : partiellement conforme" => "partiellement",
-      "accessibilité de ce site : totalement conforme" => "totalement",
-      "accessibilité : totalement non conforme" => "non",
-      "accessibilité : fantastiquement conforme" => nil,
+      "accessibilité : totalement conforme" => "totalement",
+      "accessibilité (non conforme)" => "non",
+      "accessibilité du site : totalement conforme" => nil,
+      "accessibilité : totalement non conforme" => nil,
+      "accessibilité : pas vraiment vraiment conforme" => nil,
     }.each do |text, expectation|
       context "when page contains '#{text}'" do
         let(:text) { text }


### PR DESCRIPTION
Allow parenthesis around level but ban words between "Accessibilité" and level.