### PR TITLE
chore: Remove live reload on site index

### DIFF
--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,5 +1,3 @@
-<%= turbo_stream_from :sites %>
-
 <div class="fr-col-6">
   <%= render "shared/filter",
              attribute: :tag_id,


### PR DESCRIPTION
- It is hard to navigate the app while an import is ongoing
- No real added value for the index