### PR TITLE
fix: Correct human_success_rate for empty comparisons

### DIFF
--- a/app/models/checks/accessibility_page_heading.rb
+++ b/app/models/checks/accessibility_page_heading.rb
@@ -32,8 +32,9 @@ module Checks
     def comparison = @comparison ||= super&.map { PageHeadingStatus.new(*it) } || []
     def total = expected_headings.count
     def failures = comparison.filter { it.error? }
+    def success_count = comparison.empty? ? 0 : total - failures.count
     def score = comparison.empty? ? 0 : (total - failures.count) / total.to_f * 100
-    def human_success_rate = "#{total - failures.count}/#{total}"
+    def human_success_rate = "#{success_count}/#{total}"
     def human_explanation = human(:explanation, total:, count: failures.count, error: failures.first.message)
     alias custom_badge_text human_success_rate
 

--- a/spec/models/checks/accessibility_page_heading_spec.rb
+++ b/spec/models/checks/accessibility_page_heading_spec.rb
@@ -164,4 +164,49 @@ RSpec.describe Checks::AccessibilityPageHeading do
       end
     end
   end
+
+  describe "#success_count" do
+    subject(:success_count) { check.success_count }
+
+    before { check.data = comparison_data }
+
+    context "when comparison is empty" do
+      let(:comparison_data) { {} }
+
+      it "returns 0" do
+        expect(success_count).to eq 0
+      end
+    end
+
+    context "when all headings are correct" do
+      let(:comparison_data) do
+        {
+          comparison: described_class::EXPECTED_HEADINGS.map do |level, heading|
+            [heading, level, :ok, heading]
+          end
+        }
+      end
+
+      it "returns total count" do
+        expect(success_count).to eq 14
+      end
+    end
+
+    context "when some headings have errors" do
+      let(:comparison_data) do
+        {
+          comparison: [
+            ["Déclaration d'accessibilité", 1, :ok, "Déclaration d'accessibilité"],
+            ["État de conformité", 2, :ok, "État de conformité"],
+            ["Résultats des tests", 3, :incorrect_level, "Résultats des tests"], # error
+            *described_class::EXPECTED_HEADINGS[3..-1].map { |level, heading| [heading, level, :missing, nil] }
+          ]
+        }
+      end
+
+      it "returns total minus failures count" do
+        expect(success_count).to eq 2
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `failures` array is empty when the check hasn't run, so `total - failures` was `14`. 