### PR TITLE
chore: Remove mission control job auth in local env

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+
+  # Disable HTTP Basic Auth for mission control jobs
+  config.mission_control.jobs.http_basic_auth_enabled = false
 end


### PR DESCRIPTION
It was just annoying.