### PR TITLE
fix: Fix missed rename from :search to :filter params

### DIFF
--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -33,7 +33,7 @@
     <% else %>
       <tr>
         <td colspan="<%= 5 + Check.classes.size %>">
-          <%= Site.human(params.dig(:search, :q).present? ? :no_search_results : :no_results) %>
+          <%= Site.human(params.dig(:filter, :q).present? ? :no_search_results : :no_results) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -11,7 +11,7 @@
       <% @tags.each do |tag| %>
         <tr>
           <td><%= dsfr_link_to tag.name, tag %></td>
-          <td><%= dsfr_link_to Tag.human(:see_sites, tag: tag.name, count: tag.sites_count), sites_path(search: { tag_id: tag.id }) %></td>
+          <td><%= dsfr_link_to Tag.human(:see_sites, tag: tag.name, count: tag.sites_count), sites_path(filter: { tag_id: tag.id }) %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -20,6 +20,6 @@
 <%= page_actions do %>
   <%= dsfr_link_to Tag.human(:edit), [:edit, @tag], class: "fr-btn fr-btn--secondary" %>
   <%= button_to Tag.human(:delete), @tag, method: :delete, class: "fr-btn fr-btn--tertiary", form: { data: { turbo_confirm: t("shared.confirm") } } %>
-  <%= dsfr_link_to Tag.human(:see_sites, tag: @tag.name, count: @tag.sites_count), sites_path(search: { tag_id: @tag.id }), class: "fr-btn fr-btn--tertiary" %>
+  <%= dsfr_link_to Tag.human(:see_sites, tag: @tag.name, count: @tag.sites_count), sites_path(filter: { tag_id: @tag.id }), class: "fr-btn fr-btn--tertiary" %>
   <%= dsfr_link_to t("shared.back_to_list"), { controller: :tags, action: :index }, class: "fr-btn fr-btn--tertiary-no-outline" %>
 <% end %>


### PR DESCRIPTION
Fix dangling references to `:search`. Files were changed in c735e4be6ee1eb2d420326d760ec89984dacaf22 and in b569b4b91c038c7f2e04fc0f9766802dbc857d3c, the PRs got merged without conflicts.