### PR TITLE
Feat: Add process upload job

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -45,7 +45,7 @@ class SitesController < ApplicationController
   def upload
     @upload = SiteUpload.new(site_upload_params)
     if @upload.save
-      redirect_to sites_path, notice: t(".uploaded", count: @upload.count)
+      redirect_to sites_path, notice: t(".started")
     else
       render :new, status: :unprocessable_content
     end

--- a/app/jobs/process_single_site_job.rb
+++ b/app/jobs/process_single_site_job.rb
@@ -1,0 +1,25 @@
+class ProcessSingleSiteJob < ApplicationJob
+  queue_as :default
+
+  def perform(site_data, team_id, tag_ids)
+    team = Team.find(team_id)
+
+    url = site_data["url"]
+    name = site_data["name"]
+    tag_names = site_data["tag_names"] || []
+
+    row_tag_ids = tag_names.map { |tag_name| team.tags.find_or_create_by(name: tag_name).id }
+    combined_tag_ids = (tag_ids + row_tag_ids).uniq
+
+    site = team.sites.find_by_url(url: url)
+
+    if site
+      site.tag_ids = combined_tag_ids.union(site.tag_ids)
+      site.name = name if name.present? && site.name.blank?
+      site.save!
+      site.audit!
+    else
+      Site.create!(url: url, team: team, name: name, tag_ids: combined_tag_ids)
+    end
+  end
+end

--- a/app/jobs/process_site_upload_job.rb
+++ b/app/jobs/process_site_upload_job.rb
@@ -1,0 +1,11 @@
+class ProcessSiteUploadJob < ApplicationJob
+  queue_as :default
+
+  def perform(sites_data, team_id, tag_ids)
+    site_jobs = sites_data.map do |site_data|
+      ProcessSingleSiteJob.new(site_data, team_id, tag_ids)
+    end
+
+    ActiveJob.perform_all_later(site_jobs) if site_jobs.any?
+  end
+end

--- a/app/services/csv_site_parser.rb
+++ b/app/services/csv_site_parser.rb
@@ -1,0 +1,50 @@
+class CsvSiteParser
+  require "csv"
+
+  BOM = /^\xEF\xBB\xBF/
+  SUPPORTED_SEPARATORS = [",", ";"].freeze
+
+  def initialize(file)
+    @file = file
+  end
+
+  def parse_data!
+    sites_by_url = {}
+
+    CSV.foreach(@file.path, headers: true, encoding: "bom|utf-8", col_sep: detect_col_sep) do |row|
+      row = row.to_h.transform_keys { |header| header.to_s.downcase }
+
+      url = Link.normalize(row["url"]).to_s
+      name = row["nom"] || row["name"]
+      tag_names = row["tags"].present? ? row["tags"].split(",").map(&:strip).compact_blank.uniq : []
+
+      if sites_by_url[url]
+        sites_by_url[url]["tag_names"] = (sites_by_url[url]["tag_names"] + tag_names).uniq
+      else
+        sites_by_url[url] = {
+          "url" => url,
+          "name" => name,
+          "tag_names" => tag_names
+        }
+      end
+    end
+
+    sites_by_url.values
+  end
+
+  def headers
+    @headers ||= (CSV.parse_line(first_line, col_sep: detect_col_sep) || []).compact_blank.map(&:downcase)
+  end
+
+  private
+
+  def first_line
+    @first_line ||= File.open(@file.path, &:gets)&.strip&.sub(BOM, "") || ""
+  end
+
+  def detect_col_sep
+    SUPPORTED_SEPARATORS.max_by { |sep| first_line.count(sep) }
+  rescue StandardError
+    SUPPORTED_SEPARATORS.first
+  end
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -329,6 +329,7 @@ fr:
       new_audit: Site existant, nouvel audit programmé
     upload:
       title: Importer des sites
+      started: Import démarré
       uploaded:
         zero: Aucun site ajouté
         one: Un site ajouté

--- a/features/page_des_sites.feature
+++ b/features/page_des_sites.feature
@@ -5,100 +5,36 @@ Fonctionnalité:
   Contexte:
     Sachant que je suis "marie.curie@gouv.fr" avec le SIRET 123 de l'organisation "DINUM"
     Et que je me pro-connecte
-    Et que je clique sur "Ajouter un site"
-
-  Scénario: Un agent peut filtrer les sites par nom de tag
-    Sachant que je possède un fichier "tmp/sites.csv" qui contient
+    Et que le site "https://beta.gouv.fr/" renvoie des réponses normales
+    Et que le site "https://numerique.gouv.fr/" renvoie des réponses normales
+    Et que le site "https://www.suresnes.fr/" renvoie des réponses normales
+    Et que je possède un fichier "tmp/sites.csv" qui contient
       """
       url;tags
       https://beta.gouv.fr;beta
       https://numerique.gouv.fr;gouv,public
       https://www.suresnes.fr;public
       """
+    Et que je choisis "Ajouter un site" dans le menu principal
     Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
-    Quand je clique sur "Importer"
-    Et que je filtre par étiquette "public"
+    Et que je clique sur "Importer"
+    Et que toutes les tâches de fond sont terminées
+    Et que je recharge la page
+
+  Scénario: Un agent peut filtrer les sites par nom de tag
+    Quand je filtre par étiquette "public"
     Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
       | suresnes.fr       |
       | numerique.gouv.fr |
 
   Scénario: Un agent peut trier les sites par URL croissantes
-    Sachant que je possède un fichier "tmp/sites.csv" qui contient
-      """
-      url
-      https://beta.gouv.fr
-      https://www.suresnes.fr
-      https://numerique.gouv.fr
-      """
-    Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
-    Quand je clique sur "Importer"
-    Et que je clique sur "Trier par Adresse du site croissant"
+    Quand je clique sur "Trier par Adresse du site croissant"
     Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
       | beta.gouv.fr      |
       | numerique.gouv.fr |
       | suresnes.fr       |
 
-  Scénario: Un agent peut combiner tri, filtre par tag et recherche
-    Sachant que je possède un fichier "tmp/sites.csv" qui contient
-      """
-      url;tags
-      https://alpha.gouv.fr;beta
-      https://beta.gouv.fr;beta
-      https://gamma.gouv.fr;public
-      https://delta.gouv.fr;public,beta
-      https://epsilon.gouv.fr;beta
-      https://theta.gouv.fr;public
-      https://iota.gouv.fr;public
-      https://kappa.gouv.fr;public
-      https://lambda.gouv.fr;public
-      https://psi.gouv.fr;public
-      https://omega.gouv.fr;public
-      """
-    Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
-    Quand je clique sur "Importer"
-    Et que je clique sur "Trier par Adresse du site croissant"
-    Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
-      | alpha.gouv.fr   |
-      | beta.gouv.fr    |
-      | delta.gouv.fr   |
-      | epsilon.gouv.fr |
-      | gamma.gouv.fr   |
-      | iota.gouv.fr    |
-      | kappa.gouv.fr   |
-      | lambda.gouv.fr  |
-      | omega.gouv.fr   |
-      | psi.gouv.fr     |
-      | theta.gouv.fr   |
-    Quand je filtre par étiquette "beta"
-    Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
-      | alpha.gouv.fr   |
-      | beta.gouv.fr    |
-      | delta.gouv.fr   |
-      | epsilon.gouv.fr |
-    Quand je recherche "a.gouv"
-    Alors la colonne "Adresse du site" du tableau "Tous les sites" contient dans l'ordre :
-      | alpha.gouv.fr |
-      | beta.gouv.fr  |
-      | delta.gouv.fr |
-
-  Scénario: Un agent peut voir les sites avec leurs liens et étiquettes
-    Sachant que je rajoute un site "https://example1.gouv.fr"
-    Et que je rajoute un site "https://example2.gouv.fr"
-    Et que le site "https://example1.gouv.fr" a les étiquettes "production, public"
-    Quand je clique sur "Tous les sites"
-    Alors la page contient un tableau
-    Et la page contient un lien vers "https://example1.gouv.fr"
-    Et la page contient un lien vers "https://example2.gouv.fr"
-    Et la page contient "production"
-    Et la page contient "public"
-
   Scénario: Un agent peut voir les statuts de vérification pour chaque site
     Sachant que je possède un site "https://example.gouv.fr" avec des données
     Quand je clique sur "Tous les sites"
-    Alors la page contient un tableau
     Et la page contient toutes les vérifications du site "https://example.gouv.fr" avec le préfixe "sites_table"
-
-  Scénario: Un agent voit un message quand aucun site n'existe
-    Quand je clique sur "Tous les sites"
-    Alors la page contient un tableau
-    Et la page contient "Aucun site"

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -4,10 +4,10 @@ def team
   @team ||= User.find_by(email: OmniAuth.config.mock_auth[:proconnect][:info][:email]).team
 end
 
-Quand("je rajoute un site {string} qui renvoie une réponse HTML normale") do |url|
+Quand("le site {string} renvoie des réponses normales") do |url|
   steps %(
-   Sachant que le site "#{url}" renvoie une réponse HTML normale
-   Et que je rajoute un site "#{url}"
+    Sachant que le site "#{url}" renvoie une réponse HTML normale pour la page d'accueil
+    Et que le site "#{url}" renvoie une réponse HTML normale pour la déclaration d'accessibilité
   )
 end
 

--- a/spec/jobs/process_single_site_job_spec.rb
+++ b/spec/jobs/process_single_site_job_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe ProcessSingleSiteJob do
+  describe "#perform" do
+    subject(:run_process_single_site_job) { described_class.new.perform(site_data, team.id, extra_tag_ids) }
+
+    let(:team) { create(:team) }
+    let(:site_data) do
+      {
+        "url" => "https://example.com/",
+        "name" => "New Name",
+        "tag_names" => ["tag_1", "tag_2"]
+      }
+    end
+    let(:extra_tag_ids) { [] }
+
+    context "when the site does not exist" do
+      it "creates a new site" do
+        expect { run_process_single_site_job }.to change(Site, :count).by(1)
+      end
+
+      it "sets the correct attributes" do
+        run_process_single_site_job
+
+        site = Site.last
+        expect(site.url).to eq("https://example.com/")
+        expect(site.name).to eq("New Name")
+        expect(site.team).to eq(team)
+      end
+
+      it "creates and associates the tags" do
+        run_process_single_site_job
+
+        site = Site.last
+        expect(site.tags.map(&:name)).to contain_exactly("tag_1", "tag_2")
+      end
+
+      context "with extra tags provided" do
+        let(:extra_tag) { create(:tag, team: team, name: "extra_tag") }
+        let(:extra_tag_ids) { [extra_tag.id] }
+
+        it "associates both CSV tags and extra tags" do
+          run_process_single_site_job
+
+          expect(Site.last.tags.map(&:name)).to contain_exactly("tag_1", "tag_2", "extra_tag")
+        end
+      end
+
+      context "when the name is missing in the CSV" do
+        let(:site_data) { { "url" => "https://example.com/", "tag_names" => [] } }
+
+        it "creates the site without a name" do
+          run_process_single_site_job
+
+          expect(Site.last.name).to be_nil
+        end
+      end
+    end
+
+    context "when the site already exists" do
+      let!(:site) { create(:site, team: team, url: "https://example.com/", name: "Original Name") }
+      let!(:existing_tag) { create(:tag, team: team, name: "existing_tag") }
+
+      before do
+        site.tags << existing_tag
+      end
+
+      it "does not create a new site" do
+        expect { run_process_single_site_job }.not_to change(Site, :count)
+      end
+
+      it "creates only new tags" do
+        expect { run_process_single_site_job }.to change(Tag, :count).by(2)
+      end
+
+      it "merges the new tags with the existing ones" do
+        run_process_single_site_job
+
+        expect(site.reload.tags.map(&:name)).to contain_exactly("existing_tag", "tag_1", "tag_2")
+      end
+
+      context "when the site name is blank" do
+        before { site.update!(name: nil) }
+
+        it "updates the name from the CSV" do
+          expect { run_process_single_site_job }.to change { site.reload.name }.from(nil).to("New Name")
+        end
+      end
+
+      context "when the site name is already present" do
+        it "does not overwrite the existing name" do
+          expect { run_process_single_site_job }.not_to change { site.reload.name }
+        end
+      end
+    end
+
+    context "with duplicate tags" do
+      let(:site_data) do
+        {
+          "url" => "https://example.com/",
+          "tag_names" => ["tag", "tag"]
+        }
+      end
+      let(:duplicate_tag) { create(:tag, team: team, name: "tag") }
+      let(:extra_tag_ids) { [duplicate_tag.id] }
+
+      it "deduplicates the tags" do
+        run_process_single_site_job
+
+        expect(Site.last.tags.map(&:name)).to contain_exactly("tag")
+      end
+    end
+  end
+end

--- a/spec/jobs/process_site_upload_job_spec.rb
+++ b/spec/jobs/process_site_upload_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ProcessSiteUploadJob do
+  subject(:job) { described_class.new }
+
+  let(:team) { create(:team) }
+  let(:sites_data) do
+    [
+      { "url" => "https://example.com/", "name" => "Example Site", "tag_names" => ["tag1"] },
+      { "url" => "https://test.com/", "name" => "Test Site", "tag_names" => ["tag2"] }
+    ]
+  end
+  let(:tag_ids) { [] }
+
+  describe "#perform" do
+    it "creates ProcessSingleSiteJob for each site" do
+      expect { job.perform(sites_data, team.id, tag_ids) }
+        .to have_enqueued_job(ProcessSingleSiteJob).exactly(:twice)
+    end
+  end
+end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Check do
   end
 
   describe "#run" do
-    let(:check) { build(:check, :accessibility_mention) }
+    let(:check) { create(:check, :accessibility_mention) }
 
     context "when the analyze method goes well" do
       before do

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe "Sites" do
 
     it "creates a site and schedules checks automatically" do
       expect { post_site }.to change(Site, :count).by(1)
-        .and change(Audit, :count).by(1)
-        .and change(Check, :count).by(Check.names.count)
+                                                  .and change(Audit, :count).by(1)
+                                                                            .and change(Check, :count).by(Check.names.count)
 
       site = Site.last
       audit = site.audit
@@ -99,7 +99,7 @@ RSpec.describe "Sites" do
     let(:file) { fixture_file_upload("sites.csv", "text/csv") }
 
     it "schedules audits and redirects to sites index" do
-      upload_mock = instance_double(SiteUpload, save: true, count: 2)
+      upload_mock = instance_double(SiteUpload, save: true)
       allow(SiteUpload).to receive(:new).and_return(upload_mock)
 
       upload_sites
@@ -107,7 +107,7 @@ RSpec.describe "Sites" do
       expect(response).to redirect_to(sites_path)
       follow_redirect!
       expect(response).to have_http_status(:ok)
-      expect(flash[:notice]).to include("2")
+      expect(flash[:notice]).to include("Import démarré")
     end
 
     context "when upload is invalid" do

--- a/spec/services/csv_site_parser_spec.rb
+++ b/spec/services/csv_site_parser_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe CsvSiteParser do
+  subject(:parser) { described_class.new(file) }
+
+  let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttps://test.com/,Test Site" }
+  let(:encoding) { Encoding::UTF_8 }
+  let(:csv) do
+    Tempfile.new(["sites", ".csv"], encoding:).tap do |f|
+      f.write(csv_content)
+      f.rewind
+    end
+  end
+  let(:file) do
+    ActionDispatch::Http::UploadedFile.new(
+      filename: "sites.csv",
+      type: "text/csv",
+      tempfile: csv
+    )
+  end
+
+  describe "#parse_data!" do
+    context "with valid CSV" do
+      let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttps://test.com/,Test Site" }
+
+      it "returns an array of site hashes" do
+        result = parser.parse_data!
+        expect(result).to contain_exactly({ "url" => "https://example.com/", "name" => "Example Site", "tag_names" => [] }, { "url" => "https://test.com/", "name" => "Test Site", "tag_names" => [] })
+      end
+    end
+
+    context "with tags column" do
+      let(:csv_content) { "url,name,tags\nhttps://example.com/,Example Site,\"tag1, tag2\"" }
+
+      it "parses tags into an array" do
+        result = parser.parse_data!
+        expect(result.first["tag_names"]).to eq(["tag1", "tag2"])
+      end
+    end
+
+    context "with duplicate URLs" do
+      let(:csv_content) { "url,name,tags\nhttps://example.com/,Example Site,tag1\nhttps://example.com/,Example Site,tag2" }
+
+      it "merges tag_names for duplicate URLs" do
+        result = parser.parse_data!
+        expect(result.length).to eq(1)
+        expect(result.first["tag_names"]).to contain_exactly("tag1", "tag2")
+      end
+    end
+
+    context "with nom column" do
+      let(:csv_content) { "url,nom\nhttps://example.com/,Site Exemple" }
+
+      it "uses nom as name" do
+        result = parser.parse_data!
+        expect(result.first["name"]).to eq("Site Exemple")
+      end
+    end
+  end
+
+  describe "#headers" do
+    let(:csv_content) { "URL,name\nhttps://example.com/,Example Site" }
+
+    it "returns lowercase headers" do
+      expect(parser.headers).to eq(["url", "name"])
+    end
+  end
+end


### PR DESCRIPTION
- Introduce `CsvSiteParser`
- Simplify `SiteUpload` model
- Add `ProcessSiteUploadJob` and `ProcessSingleSiteJob` for parallelized site processing
- Fix audit callback to use `after_create` instead of `after_create_commit`