### PR TITLE
fix: Fix accessibility page detection error

### DIFF
--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -35,7 +35,7 @@ module Checks
 
     def required_headings_present?(current_page)
       matching_headings = current_page.headings.select do |heading|
-        AccessibilityPageHeading.expected_headings.each do |required_heading|
+        AccessibilityPageHeading.expected_headings.any? do |required_heading|
           fuzzy_match?(heading, required_heading)
         end
       end

--- a/spec/models/checks/find_accessibility_page_spec.rb
+++ b/spec/models/checks/find_accessibility_page_spec.rb
@@ -100,10 +100,11 @@ RSpec.describe Checks::FindAccessibilityPage do
 
     let(:page) { build(:page, headings:, body: "") }
     let(:expected_headings) { Checks::AccessibilityPageHeading.expected_headings }
+    let(:unrelated_headings) { ["Contact", "Accueil", "Actualités"] }
 
     [0, 2, 3, 6].each do |i|
       context "when #{i} required headings are present" do
-        let(:headings) { expected_headings.first(i) }
+        let(:headings) { unrelated_headings + expected_headings.first(i) }
 
         it { should eq(i >= described_class::REQUIRED_DECLARATION_HEADINGS) }
       end


### PR DESCRIPTION
Avec `each` au lieu de `any?` le test renvoyait toujours true, donc n'importe quelle page passait du moment qu'elle avait des titres, et la spec ne le détectait pas parce qu'elle n'incluait pas assez de titres pour déclencher le comportement erroné.