### PR TITLE
fix: Page headings comparison needs to have access to the headings

### DIFF
--- a/app/models/checks/accessibility_page_heading.rb
+++ b/app/models/checks/accessibility_page_heading.rb
@@ -50,8 +50,9 @@ module Checks
     def analyze!
       return unless page = audit.page(:accessibility)
 
+      self.page_headings = page.heading_levels
       {
-        page_headings: page.heading_levels,
+        page_headings:,
         comparison: compare_headings
       }
     end


### PR DESCRIPTION
On first pass, `AccessibilityPageHeading.analyze!` always returns an empty comparison because page_headings is not yet available. The spec incorrectly passed because it focused on the complex `compare_headings` method and mocked `page_headings`. 