### PR TITLE
feat: Limit touching session to once a day

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,7 +30,7 @@ module Authentication
   end
 
   def resume_session
-    Current.session ||= find_session_by_cookie&.tap { |session| session.touch if session.touch? }
+    Current.session ||= find_session_by_cookie&.tap { |session| session.touch if session.should_touch? }
   end
 
   def find_session_by_cookie

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,5 +6,5 @@ class Session < ApplicationRecord
   scope :active, -> { where(updated_at: MAX_IDLE_TIME.ago..) }
   scope :inactive, -> { where(updated_at: ...MAX_IDLE_TIME.ago) }
 
-  def touch? = updated_at.before?(1.day.ago)
+  def should_touch? = updated_at.before?(1.day.ago)
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe Session do
     end
   end
 
-  describe "#touch?" do
+  describe "#should_touch?" do
     context "when session was updated more than 1 day ago" do
       it "returns true" do
         session = build(:session, updated_at: 2.days.ago)
 
-        expect(session.touch?).to be true
+        expect(session.should_touch?).to be true
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Session do
       it "returns false" do
         session = build(:session, updated_at: 1.hour.ago)
 
-        expect(session.touch?).to be false
+        expect(session.should_touch?).to be false
       end
     end
   end


### PR DESCRIPTION
Since ccec063bbf8f64b3b55f3d8cdbe0fd770a7c105a, viewing (or even hovering over a link, due to Turbo-prefech) touches the session, which in turn touches the user, which in turn touches the team (3 SQL updates).
We don't need to know exactly when the current_user last interacted with the app.