### PR TITLE
fix: Fix crash for double slash links

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -13,6 +13,7 @@ Link = Data.define(:href, :text) do
     end
 
     def parse(href)
+      href = "/" if href == "//" # Addressable considers // to be an absolute url instead of a path
       Addressable::URI.parse(href.to_s.strip)
     rescue Addressable::URI::InvalidURIError
       raise Link::InvalidUriError.new(href)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -66,7 +66,7 @@ class Page
       next if uri.path && File.extname(uri.path).match?(FILES_EXTENSIONS)
       next if skip_files && uri.path && File.extname(uri.path).match?(DOCUMENT_EXTENSIONS)
 
-      href = parsed_root.join(href) unless uri.absolute?
+      href = parsed_root.join(uri) unless uri.absolute?
       text = [link.text, link.at_css("img")&.attribute("alt")&.value].compact.join(" ").squish
       Link.new(href:, text:)
     rescue Link::InvalidUriError

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -255,6 +255,11 @@ RSpec.describe Link do
       link = described_class.new(href: "https://example.com", text: nil)
       expect(link.text).to eq("")
     end
+
+    it "handles //" do
+      link = described_class.new(href: "https://example.com//", text: nil)
+      expect(link.href).to eq("https://example.com/")
+    end
   end
 
   describe "#to_str" do


### PR DESCRIPTION
On https://mouguerre.fr/accessibilite-du-site, there's a link to `<a href="//">` which Addressable::URI interprets as a protocol-agnostic link without host and path. Joining this path to the current root was performed  inside `page.links`, outside of a Link method that handles `Addressable::URI::InvalidURIError`, thus crashing `FindAccessibilityPage`.