### PR TITLE
fix: Store status, headers and actual_url when caching a page

### DIFF
--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -163,8 +163,9 @@ RSpec.describe Page do
     it "attempts to use the cache" do
       allow(Rails.cache).to receive(:fetch)
         .with(normalized_url, expires_in: described_class::CACHE_TTL)
+        .and_call_original
 
-      page
+      page.html
       expect(Rails.cache).to have_received(:fetch)
         .with(normalized_url, expires_in: described_class::CACHE_TTL)
     end
@@ -173,7 +174,7 @@ RSpec.describe Page do
       let(:headers) { { "Content-Type" => "application/pdf" } }
 
       it "raises InvalidTypeError" do
-        expect { page }.to raise_error(Page::InvalidTypeError, /Not an HTML page.*application\/pdf/)
+        expect { page.html }.to raise_error(Page::InvalidTypeError, /Not an HTML page.*application\/pdf/)
       end
     end
   end


### PR DESCRIPTION
Requesting `page.status` or `page.headers` while a page was cached returned `nil`, preventing new audits until the cache expired. Storing `status`, `current_url`, `headers`, and `html` in a hash and using explicit accessors fixes the problem. The `@fetch` instance variable allows storing data in-memory for repeat access during the object lifetime, avoiding the slightly expensive cache-fetch.