### PR TITLE
feat: Extract the latest plan and schema from main text

### DIFF
--- a/app/models/checks/analyze_plan.rb
+++ b/app/models/checks/analyze_plan.rb
@@ -89,7 +89,7 @@ module Checks
 
     def extract_years(*sources)
       sources.compact.each do |source|
-        years = source.to_s.scan(/\d{4}/).map(&:to_i).sort
+        years = source.to_s.scan(/\d{4}/).map(&:to_i).uniq.sort
         return years if years.present?
       end
       []

--- a/app/models/checks/analyze_schema.rb
+++ b/app/models/checks/analyze_schema.rb
@@ -100,7 +100,7 @@ module Checks
 
     def extract_years(*sources)
       sources.compact.each do |source|
-        years = source.to_s.scan(/\d{4}/).map(&:to_i).sort
+        years = source.to_s.scan(/\d{4}/).map(&:to_i).uniq.sort
         return years if years.present?
       end
       []

--- a/spec/models/checks/analyze_plan_spec.rb
+++ b/spec/models/checks/analyze_plan_spec.rb
@@ -287,6 +287,7 @@ RSpec.describe Checks::AnalyzePlan do
     {
       "Plan annuel d'accessibilité" => [],
       "Plan annuel d'accessibilité 2024" => [2024],
+      "uploads/2025/plan-annuel-202502.pdf" => [2025],
       "PLAN ANNUEL D'ACCESSIBILITE NUMERIQUE 2023-2025" => [2023, 2025],
       "PLAN ANNUEL D'ACCESSIBILITE NUMERIQUE 2025-2023" => [2023, 2025],
     }.each do |text, expected_result|

--- a/spec/models/checks/analyze_schema_spec.rb
+++ b/spec/models/checks/analyze_schema_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe Checks::AnalyzeSchema do
     {
       "Schéma pluriannuel d'accessibilité" => [],
       "Schéma pluriannuel d'accessibilité 2024" => [2024],
+      "uploads/2025/schema-pluri-annuel-202502.pdf" => [2025],
       "SCHEMA PLURIANNUEL D'ACCESSIBILITE NUMERIQUE 2023-2025" => [2023, 2025],
       "SCHEMA PLURIANNUEL D'ACCESSIBILITE NUMERIQUE 2025-2023" => [2023, 2025],
     }.each do |text, expected_result|


### PR DESCRIPTION
When there were multiple matches, the `find_link` method in `AnalyzePlan` and `AnalyzeSchema` returned the link with the highest years, but `find_text_in_main` returned the first result.

This fixes plan detection in https://metropole.nantes.fr/declaration-d-accessibilite-accessibilite-partiellement-conforme because it has the following headings:
- Plan d’actions 2021-2023
- Plan d’actions 2024-2025