### PR TITLE
fix: Remove page caching

### DIFF
--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Page do
   let(:url) { "https://éxample.com/about" }
   let(:normalized_url) { Link.normalize(url) }
   let(:page) { build(:page, url:, root:, html: body) }
-  let(:headers) { { "Content-Type" => "text/html" } }
+  let(:headers) { { "content-type" => "text/html" } }
   let(:body) do
     <<~HTML
       <!DOCTYPE html>
@@ -160,42 +160,12 @@ RSpec.describe Page do
       expect(page.html).to be_nil
     end
 
-    it "attempts to use the cache" do
-      allow(Rails.cache).to receive(:fetch)
-        .with(normalized_url, expires_in: described_class::CACHE_TTL)
-
-      page
-      expect(Rails.cache).to have_received(:fetch)
-        .with(normalized_url, expires_in: described_class::CACHE_TTL)
-    end
-
     context "when the response is not HTML" do
-      let(:headers) { { "Content-Type" => "application/pdf" } }
+      let(:headers) { { "content-type" => "application/pdf" } }
 
       it "raises InvalidTypeError" do
         expect { page }.to raise_error(Page::InvalidTypeError, /Not an HTML page.*application\/pdf/)
       end
-    end
-  end
-
-  describe "#refresh" do
-    let(:body) { nil }
-    let(:new_body) { "<html><body><h1>Refreshed Content</h1></body></html>" }
-
-    before do
-      allow(Browser).to receive(:get)
-        .with(normalized_url)
-        .and_return({ body: new_body, status: 200, headers:, current_url: normalized_url })
-    end
-
-    it "clears the cache and calls Browser.get" do
-      expect(Rails.cache).to receive(:clear).with(normalized_url)
-      expect(Browser).to receive(:get).with(normalized_url)
-      page.refresh
-    end
-
-    it "returns self for method chaining" do
-      expect(page.refresh).to eq(page)
     end
   end
 


### PR DESCRIPTION
- Remove caching in `Page` model and associated specs.
- Remove unused `refresh` method.
- In page.rb, the usage of the `html` parameter is only for tests and will be handled in another PR.
- This fixes 3 bugs:
  - New verifications were failing because of the cache handling and missed initialization of some attributes.
  - 2 different audits from different teams or users were sharing the same cached data because the cache key was not unique (url).
  - No Content-Type header was found or set. This is expected since Ferrum returns all headers in lowercase
- These bugs combined triggered a major issue: when someone from a team is launching an audit, the next audit from any team on the same site would completely fail.
- Decisions:
  - Tech POV: caching is not needed at this stage. It's early optimization.
  - Product POV: caching is undesirable because it misleads users and cached audits do not reflect reality.