### PR TITLE
chore: Update `brakeman` gem to version `~> 7.1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ group :development, :test do
   gem "pry-rails"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.1", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -686,7 +686,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  brakeman
+  brakeman (~> 7.1)
   capybara
   cld
   csv


### PR DESCRIPTION
- Add versioning to enable dependabot PRs on brakeman bumps