### PR TITLE
Fix: Use content_type from Ferrum

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -127,8 +127,8 @@ class Browser
       page.go_to(url)
       {
         body: page.body,
-        status: page.network.status || 200,
-        headers: page.network.response&.headers || {},
+        status: page.network.status,
+        content_type: page.network.response.content_type,
         current_url: Link.normalize(page.current_url)
       }
     end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -19,7 +19,7 @@ class Page
     end
   end
 
-  attr_reader :url, :root, :status, :html, :headers, :actual_url
+  attr_reader :url, :root, :status, :html, :actual_url
 
   def initialize(url:, root: nil, html: nil)
     @url = Link.normalize(url)
@@ -75,18 +75,17 @@ class Page
   def setup_page_data
     @actual_url = @url
     @status = 200
-    @headers = { "content-type" => "text/html" }
+    @content_type =  "text/html"
   end
 
   def is_html_page?
-    content_type = @headers["content-type"]
-    content_type && content_type.include?("text/html")
+    @content_type && @content_type.include?("text/html")
   end
 
   def fetch_page_data
-    @actual_url, @status, @headers, @html = Browser.get(url.to_s).values_at(:current_url, :status, :headers, :body)
+    @actual_url, @status, @content_type, @html = Browser.get(url.to_s).values_at(:current_url, :status, :content_type, :body)
 
-    raise InvalidTypeError.new(url, @headers["content-type"]) unless is_html_page?
+    raise InvalidTypeError.new(url, @content_type) unless is_html_page?
   end
 
   def dom_headings

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Page do
   let(:url) { "https://éxample.com/about" }
   let(:normalized_url) { Link.normalize(url) }
   let(:page) { build(:page, url:, root:, html: body) }
-  let(:headers) { { "content-type" => "text/html" } }
+  let(:content_type) { "text/html" }
   let(:body) do
     <<~HTML
       <!DOCTYPE html>
@@ -42,7 +42,7 @@ RSpec.describe Page do
   end
 
   before do
-    stub_request(:get, url).to_return(body:, headers:)
+    stub_request(:get, url).to_return(body:, headers: { "content-type": content_type })
 
     # Mock Browser to prevent real Ferrum::Browser instantiation
     ferrum_browser = instance_double(Ferrum::Browser)
@@ -153,7 +153,7 @@ RSpec.describe Page do
     before do
       allow(Browser).to receive(:get)
         .with(normalized_url)
-        .and_return({ body:, status: 200, headers:, current_url: normalized_url })
+        .and_return({ body:, status: 200, content_type:, current_url: normalized_url })
     end
 
     it "fetches the page content" do
@@ -161,7 +161,7 @@ RSpec.describe Page do
     end
 
     context "when the response is not HTML" do
-      let(:headers) { { "content-type" => "application/pdf" } }
+      let(:content_type) { "application/pdf" }
 
       it "raises InvalidTypeError" do
         expect { page }.to raise_error(Page::InvalidTypeError, /Not an HTML page.*application\/pdf/)


### PR DESCRIPTION
- Simplify content type handling by replacing `headers` hash with a dedicated `content_type` attribute that is already handled and lowercased by Ferrum