### PR TITLE
fix: Remove link sorting logic in find accessibility page

### DIFF
--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -51,7 +51,6 @@ module Checks
         link.text.match?(DECLARATION) ||
         link.href.match?(DECLARATION_URL)
       end
-      queue.sort_by! { |link| link.href.length }
     end
   end
 end

--- a/spec/models/checks/find_accessibility_page_spec.rb
+++ b/spec/models/checks/find_accessibility_page_spec.rb
@@ -123,13 +123,6 @@ RSpec.describe Checks::FindAccessibilityPage do
     let(:unrelated_link) { build(:link, text: "Contact", href: "/contact") }
     let(:queue) { LinkList.new(long_declaration_link, declaration_daccessibilite_link, declaration_text_link, accessibility_mention_link, short_rgaa_link, unrelated_link) }
 
-    it "filters queue and sorts links by href length" do
-      check.send(:prioritize, queue)
-
-      expect(queue.to_a).to eq ["/rgaa", "/other", "/handicap", "/declaration-accessibilite", "/declaration-daccessibilite"]
-      expect(queue.to_a).not_to include("/contact")
-    end
-
     it "keeps links matching DECLARATION pattern in text" do
       queue = LinkList.new(declaration_text_link, unrelated_link)
       check.send(:prioritize, queue)


### PR DESCRIPTION
- Delete `sort_by href length` logic in `FindAccessibilityPage`.
- Initially implemented to save time at the crawl, it was breaking for several cases

Fixing:

https://accessibilite.numerique.gouv.fr/
https://www.info.gouv.fr/