### PR TITLE
fix: Add browser instance handling in check runs

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -83,8 +83,6 @@ class Browser
   delegate :request_headers, to: :class
 
   class << self
-    delegate_missing_to :new
-
     def reachable?(url) = url && head(url)[:status] == SUCCESS_CODE
 
     def head(url)
@@ -147,15 +145,6 @@ class Browser
     end
   end
 
-  private
-
-  def browser
-    cleanup! if crashed?
-    @browser ||= Ferrum::Browser.new(settings).tap do |browser|
-      browser.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
-    end
-  end
-
   def cleanup!
     if @browser
       @browser.reset
@@ -166,6 +155,15 @@ class Browser
   ensure
     FileUtils.rm_rf(@user_data_dir) if @user_data_dir && Dir.exist?(@user_data_dir)
     @browser = nil
+  end
+
+  private
+
+  def browser
+    cleanup! if crashed?
+    @browser ||= Ferrum::Browser.new(settings).tap do |browser|
+      browser.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
+    end
   end
 
   def pid = @browser&.process&.pid
@@ -190,7 +188,6 @@ class Browser
       raise error
     ensure
       page&.close
-      cleanup!
     end
   end
 

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -80,18 +80,23 @@ class Check < ApplicationRecord
 
   def human_status = Check.human("status.#{state_machine.current_state}")
   def to_partial_path = model_name.i18n_key.to_s
-  def root_page = @root_page ||= Page.new(url: audit.url)
-  def crawler(crawl_up_to: nil) = Crawler.new(audit.url, crawl_up_to:)
+  def root_page = @root_page ||= Page.new(url: audit.url, browser: @browser)
+  def crawler(crawl_up_to: nil) = Crawler.new(audit.url, crawl_up_to:, browser: @browser)
+  def browser = @browser || Browser.new
   def requirements = self.class::REQUIREMENTS # Returns subclass constant value, defaults to parent class
   def tooltip? = true
   def slow? = self.class::SLOW
 
   def run!
+    @browser = browser
     self.data = analyze!
 
     save!
   rescue StandardError => exception
     raise Check::RuntimeError
+
+  ensure
+    @browser.cleanup!
   end
 
   def all_requirements_met?

--- a/app/models/checks/run_axe_on_homepage.rb
+++ b/app/models/checks/run_axe_on_homepage.rb
@@ -28,7 +28,7 @@ module Checks
     private
 
     def analyze!
-      return unless (results = Browser.axe_check(audit.url))
+      return unless (results = browser.axe_check(audit.url))
 
       {
         passes: results["passes"]&.count || 0,

--- a/app/models/crawler.rb
+++ b/app/models/crawler.rb
@@ -2,11 +2,12 @@ class Crawler
   include Enumerable
   MAX_CRAWLED_PAGES = 5
 
-  def initialize(root, crawl_up_to: nil)
+  def initialize(root, crawl_up_to: nil, browser: nil)
     @root = Link.from(Link.root_from(root))
     @crawl_up_to = crawl_up_to || MAX_CRAWLED_PAGES
     @queue = LinkList.new(root)
     @crawled = LinkList.new
+    @browser = browser
   end
 
   def find(&block)
@@ -33,7 +34,7 @@ class Crawler
   def get_page
     crawled << link = queue.shift
     Rails.logger.info { "#{crawled.size}: Crawling #{link.href}" }
-    Page.new(url: link.href, root: root.href)
+    Page.new(url: link.href, root: root.href, browser: @browser)
   rescue StandardError => e
     case e
     when Page::InvalidTypeError

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -21,10 +21,11 @@ class Page
 
   attr_reader :url, :root, :status, :html, :actual_url
 
-  def initialize(url:, root: nil, html: nil)
+  def initialize(url:, root: nil, html: nil, browser: nil)
     @url = Link.normalize(url)
     @root = root ? Link.normalize(root) : Link.root_from(url)
     @html = html
+    @browser = browser || Browser.new
 
     html.present? ? setup_page_data : fetch_page_data
  end
@@ -83,7 +84,7 @@ class Page
   end
 
   def fetch_page_data
-    @actual_url, @status, @content_type, @html = Browser.get(url.to_s).values_at(:current_url, :status, :content_type, :body)
+    @actual_url, @status, @content_type, @html = @browser.get(url.to_s).values_at(:current_url, :status, :content_type, :body)
 
     raise InvalidTypeError.new(url, @content_type) unless is_html_page?
   end


### PR DESCRIPTION
- Introduce browser instance sharing across audit checks.
- Update `Check`, `Page`, `Crawler` to accept and manage a `Browser` instance.
- Ensure proper `Browser` cleanup after usage to prevent resource leaks.