### PR TITLE
browser: actually use a blocklist

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -44,7 +44,11 @@ class Browser
     "twitter.com",
     "linkedin.com",
     "doubleclick.net",
-    "adservice.google.com"
+    "adservice.google.com",
+    "youtube.com",
+    "play.google.com",
+    "sites.statistiques.online",
+    "googleapis.com",
   ].then { |domains| Regexp.union(domains) }
 
   AXE_SOURCE_PATH = Rails.root.join("vendor/javascript/axe.min.js").freeze
@@ -151,9 +155,8 @@ class Browser
 
   def browser
     cleanup! if crashed?
-    @browser ||= Ferrum::Browser.new(settings).tap do |browser|
-      browser.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
-    end
+
+    @browser ||= Ferrum::Browser.new(settings)
   end
 
   def cleanup!
@@ -197,6 +200,7 @@ class Browser
   def create_page
     browser.create_page.tap do |page|
       page.headers.set(request_headers)
+      page.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
       page.network.wait_for_idle(timeout: PAGE_TIMEOUT)
     end
   end


### PR DESCRIPTION
From the commit: 

> We want to set the blocklist on the page's context rather than the browser's root context/page, which we never use: we use a dedicated page (c.f create_page) per check, which is logical and also the recommended way in the Ferrum docs.
> 
> Which is why after a bit of testing turns out nothing was blocked which means Chrome ended up making lots of requests and probably saturating the max number of connections on the websocket (which appears to be ~256 from a quick online search).
> 
> This fix should buy us enough time to fine-tune the process and prevent the daunted Ferrum::DeadBrowserError/Ferrum::TimeoutError, because a lot less requests should be made and Chrome should survive much longer.