### PR TITLE
chore: Store HTML pages for audits

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -101,11 +101,11 @@ class Check < ApplicationRecord
   end
 
   def root_page
-    @root_page ||= Page.new(url: audit.url)
+    @root_page ||= audit.page(:home)
   end
 
   def crawler(crawl_up_to: nil)
-    Crawler.new(audit.url, crawl_up_to:)
+    Crawler.new(audit.url, crawl_up_to:, root_page_html: audit.home_page_html)
   end
 
   def requirements

--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -30,6 +30,8 @@ module Checks
     def analyze!
       return unless (page = find_page)
 
+      audit.update(accessibility_page_html: page.html)
+
       { url: page.url, title: page.title }
     end
 

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -23,9 +23,11 @@ module Checks
     def analyze!
       return unless root_page.success?
 
+      audit.update!(home_page_html: root_page.html)
+
       site.update(name: root_page.title) if site && site.name.blank?
       if root_page.redirected?
-        audit.update(url: root_page.actual_url)
+        audit.update!(url: root_page.actual_url)
         { original_url: root_page.url, redirect_url: root_page.actual_url }
       else
         {}

--- a/db/migrate/20251120092907_add_pages_to_audits.rb
+++ b/db/migrate/20251120092907_add_pages_to_audits.rb
@@ -1,0 +1,6 @@
+class AddPagesToAudits < ActiveRecord::Migration[8.0]
+  def change
+    add_column :audits, :home_page_html, :text
+    add_column :audits, :accessibility_page_html, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_01_142718) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_20_092907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_142718) do
     t.datetime "updated_at", null: false
     t.datetime "checked_at"
     t.boolean "current", default: false, null: false
+    t.text "home_page_html"
+    t.text "accessibility_page_html"
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
     t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Audit do
     subject(:page) { audit.page(kind) }
 
     let(:audit) { create(:audit, :without_checks, url: "https://example.com") }
-    let(:mock_page) { instance_double(Page) }
+    let(:mock_page) { instance_double(Page, html: nil) }
 
     before do
       allow(Page).to receive(:new).and_return(mock_page)
@@ -87,7 +87,7 @@ RSpec.describe Audit do
       let(:kind) { :home }
 
       it "creates a Page with the audit url" do
-        expect(Page).to receive(:new).with(url: audit.url, root: audit.url)
+        expect(Page).to receive(:new).with(url: audit.url, root: audit.url, html: nil)
         page
       end
 
@@ -107,7 +107,7 @@ RSpec.describe Audit do
         end
 
         it "creates a Page with the accessibility page url" do
-          expect(Page).to receive(:new).with(url: "#{audit.url}/accessibilite", root: audit.url)
+          expect(Page).to receive(:new).with(url: "#{audit.url}/accessibilite", root: audit.url, html: nil)
           page
         end
 

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Check do
     it "returns a Page with the audit URL" do
       audit = build(:audit, url: "https://example.com/")
       check = build(:check, :accessibility_mention, audit:)
-      expect(Page).to receive(:new).with(url: "https://example.com/")
+      expect(Page).to receive(:new).with(url: "https://example.com/", root: "https://example.com/", html: nil)
       check.root_page
     end
   end

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Checks::Reachable do
   let(:check) { described_class.new }
   let(:original_url) { "https://example.com" }
   let(:redirect_url) { "https://example.org" }
-  let(:audit) { instance_double(Audit, url: original_url, update: true) }
-  let(:root_page) { instance_double(Page) }
+  let(:audit) { instance_double(Audit, url: original_url, update!: true) }
+  let(:root_page) { instance_double(Page, html: nil) }
   let(:site) { build(:site) }
 
   before do
@@ -73,7 +73,7 @@ RSpec.describe Checks::Reachable do
         end
 
         it "updates the audit with the new URL" do
-          expect(audit).to receive(:update).with(url: redirect_url)
+          expect(audit).to receive(:update!).with(url: redirect_url)
           check.send(:analyze!)
         end
 

--- a/spec/models/crawler_spec.rb
+++ b/spec/models/crawler_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Crawler do
 
     before do
       allow(Page).to receive(:new)
-        .with(url: root_url, root: root_url)
+        .with(url: root_url, root: root_url, html: nil)
         .and_return(root_page)
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Crawler do
 
       before do
         allow(Page).to receive(:new)
-          .with(url: link1.href, root: root_url)
+          .with(url: link1.href, root: root_url, html: nil)
           .and_return(target_page)
       end
 


### PR DESCRIPTION

- Add `home_page_html` and `accessibility_page_html` columns to `audits` table.
- Persist HTML pages in audits for error context and history
- Stop using a new browser for every checks

---

### Cache vs DB

**Long-term retention**: Cache is ephemeral. Audit HTML needs to survive to provide historical comparison and/or error context.

### PG compression
PG use  by default compression on all text columns.
If need we can still do it now or later by:
- Migration columns from text to binary
- Backfill data from text to binary with `Zlib::Deflate.deflate(text)`
- Implement methods to compress and decompress data in Audit model with `Zlib::Deflate.deflate(text) && Zlib::Inflate.inflate(binary)`
