### PR TITLE
e2e: add some plumbing to test the jobs architecture

### DIFF
--- a/features/page_des_sites.feature
+++ b/features/page_des_sites.feature
@@ -82,8 +82,8 @@ Fonctionnalité:
       | delta.gouv.fr |
 
   Scénario: Un agent peut voir les sites avec leurs liens et étiquettes
-    Sachant que je possède un site "https://example1.gouv.fr"
-    Et que je possède un site "https://example2.gouv.fr"
+    Sachant que je rajoute un site "https://example1.gouv.fr"
+    Et que je rajoute un site "https://example2.gouv.fr"
     Et que le site "https://example1.gouv.fr" a les étiquettes "production, public"
     Quand je clique sur "Tous les sites"
     Alors la page contient un tableau

--- a/features/page_du_site.feature
+++ b/features/page_du_site.feature
@@ -35,7 +35,7 @@ Fonctionnalité: Page du site
     Alors la page est titrée "éticouette"
 
   Scénario: Un agent peut voir un lien sur chaque étiquette associée au site
-    Sachant que je possède un site "https://example.gouv.fr"
+    Sachant que je rajoute un site "https://example.gouv.fr"
     Et que le site "https://example.gouv.fr" a les étiquettes "production, public"
     Quand je clique sur "Tous les sites"
     Et que je clique sur "Voir la fiche de example.gouv.fr"
@@ -43,6 +43,9 @@ Fonctionnalité: Page du site
     Et la page contient un lien vers l'étiquette "production"
     Et la page contient un lien vers l'étiquette "public"
 
+  # FIXME: ce scénario trahit le parcours utilisateur en créant
+  # manuellement des données pour chaque vérification
+  @wip
   Scénario: Un agent peut voir les informations et vérifications de l'audit
     Sachant que je possède un site "https://example.gouv.fr" avec des données
     Quand je clique sur "Tous les sites"
@@ -51,14 +54,14 @@ Fonctionnalité: Page du site
     Et la page contient toutes les vérifications du site "https://example.gouv.fr"
 
   Scénario: Un agent peut voir l'historique des audits
-    Sachant que je possède un site "https://example.gouv.fr"
+    Sachant que je rajoute un site "https://example.gouv.fr"
     Et que je demande une nouvelle vérification du site "https://example.gouv.fr"
     Quand je clique sur "Tous les sites"
     Et que je clique sur "Voir la fiche de example.gouv.fr"
     Alors la page contient "Historique des vérifications"
 
   Scénario: Un agent voit un message quand le site n'a pas d'étiquettes
-    Sachant que je possède un site "https://example.gouv.fr"
+    Sachant que je rajoute un site "https://example.gouv.fr"
     Quand je clique sur "Tous les sites"
     Et que je clique sur "Voir la fiche de example.gouv.fr"
     Alors la page contient "Aucune étiquette"

--- a/features/step_definitions/import_steps.rb
+++ b/features/step_definitions/import_steps.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Quand("je possède un fichier {string} qui contient") do |path, content|
+  File.write(path, content)
+end
+
+Quand("je rajoute un CSV de {int} sites") do |n|
+  csv = FactoryBot
+          .build_list(:site, n)
+          .map(&:url)
+          .unshift("URL")
+          .join("\n")
+
+  steps %(
+    Sachant que je clique sur "Ajouter un site"
+    Et que je possède un fichier "tmp/sites.csv" qui contient
+      """
+      #{csv}
+      """
+    Et que j'attache le fichier "tmp/sites.csv" pour le champ "Fichier CSV"
+    Et que je clique sur "Importer"
+  )
+end

--- a/features/step_definitions/job_steps.rb
+++ b/features/step_definitions/job_steps.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+After do
+  clear_enqueued_jobs
+end
+
+Quand("les tâches de fond sont terminées") do
+  perform_enqueued_jobs
+end
+
+# ce step sert à délencher et épuiser toutes les tâches qu'une tâche
+# elle-même peut programmer, ex : ProcessAuditJob déclenche plusieurs
+# RunCheckJobs.
+Quand("toutes les tâches de fond sont terminées") do
+  while queue_adapter.enqueued_jobs.any?
+    step("les tâches de fond sont terminées")
+  end
+end

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -4,8 +4,44 @@ def team
   @team ||= User.find_by(email: OmniAuth.config.mock_auth[:proconnect][:info][:email]).team
 end
 
-Quand("je possède un fichier {string} qui contient") do |path, content|
-  File.write(path, content)
+Quand("je rajoute un site {string} qui renvoie une réponse HTML normale") do |url|
+  steps %(
+   Sachant que le site "#{url}" renvoie une réponse HTML normale
+   Et que je rajoute un site "#{url}"
+  )
+end
+
+# FIXME: because Chrome goes through the "real" network, we cannot use
+# Webmock to mock the requests: Webmock will hijack `net/http` and
+# other low-level Ruby network libraries but not the actual network,
+# which means our test Chrome does go fetch actual websites. A good
+# solution would be using toxiproxy[1] to feed as a proxy to
+# Chrome and then mock responses + potential outages, etc.
+#
+# [1]: https://github.com/Shopify/toxiproxy
+
+# In the meantime mock our Browser.get method instead but that is NOT
+# NICE and we should do something about it soon.
+Sachantque("le site {string} renvoie une réponse HTML normale") do |url|
+  fake_html = <<~HTML
+        <html>
+          <head>
+            <title>Site title</title>
+          </head>
+          <body>
+            <h1>Hello</h1>
+          </body>
+        </html>
+      HTML
+
+  allow(Browser)
+    .to receive(:get)
+    .and_return(
+      body: fake_html,
+      status: 200,
+      content_type: "text/html",
+      current_url: url
+    )
 end
 
 Quand("je filtre par étiquette {string}") do |tag|
@@ -20,10 +56,12 @@ Quand("je recherche {string}") do |term|
   click_button "Rechercher"
 end
 
-Quand("je possède un site {string}") do |url|
-  site = FactoryBot.create(:site, :checked, url:, team:)
-  site.reload
-  site.set_current_audit!
+Quand("je rajoute un site {string}") do |url|
+  steps %(
+    Quand je clique sur "Ajouter un site"
+    Et que je remplis "Adresse du site" avec "#{url}"
+    Et que je clique sur "Ajouter"
+  )
 end
 
 Quand("je possède un site {string} avec des données") do |url|
@@ -80,5 +118,11 @@ Alors("la page contient toutes les vérifications du site {string}") do |url|
   site = team.sites.find_by_url(url:)
   site.audit.all_checks.each do |check|
     expect(page).to have_content(check.human_type)
+  end
+end
+
+Alors('la vérification {string} indique {string}') do |name, state|
+  within(find('h2', text: name).sibling('.fr-badge')) do |badge|
+    expect(badge).to have_content state
   end
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Quand("je recharge la page") do
+  refresh
+end

--- a/features/support/job.rb
+++ b/features/support/job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+World(ActiveJob::TestHelper)

--- a/features/support/steps.rb
+++ b/features/support/steps.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require 'betagouv/cucumber/steps'
+require 'cucumber/rspec/doubles'

--- a/features/support/web.rb
+++ b/features/support/web.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+WebMock.disable_net_connect!

--- a/features/verification_de_site.feature
+++ b/features/verification_de_site.feature
@@ -1,0 +1,16 @@
+# language: fr
+
+Fonctionnalité: Vérifications d'un site
+  Contexte:
+    Sachant que je suis "marie.curie@gouv.fr" avec le SIRET 123 de l'organisation "DINUM"
+    Et que je me pro-connecte
+    Et que je rajoute un site "http://foobar.com/" qui renvoie une réponse HTML normale
+
+  Scénario: je peux voir que les vérifications vont être lancées
+    Alors la page contient "État : Planifié"
+
+  Scénario: je peux voir quand l'audit est fini
+    Quand toutes les tâches de fond sont terminées
+    Et que je recharge la page
+    Alors la page contient "Executé le : "
+    Et la vérification "Site joignable" indique "Joignable à l'adresse indiquée"


### PR DESCRIPTION
📖 : 

> A lot of our core business logic happens in jobs (ProcessAuditJob + RunCheckJob) so introduce the code to exert that logic thanks to ActiveJob's testing API and some nice Cucumber steps.