### PR TITLE
gem: remove pry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,9 +88,6 @@ gem "cld"
 group :development, :test do
   gem "debug"
 
-  # FIXME: ideally we all migrate to Ruby's debug above
-  gem "pry-rails"
-
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", "~> 7.1", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,8 +428,6 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.11)
-      pry (>= 0.13.0)
     psych (5.2.6)
       date
       stringio
@@ -716,7 +714,6 @@ DEPENDENCIES
   pagy
   pg (~> 1.6)
   propshaft
-  pry-rails
   puma (>= 5.0)
   rack-mini-profiler
   rails (~> 8.0.4)


### PR DESCRIPTION
we already use ruby/debug[1] for our debugging purposes and having pry on top is confusing because we get two different prompts/interfaces when we debug (debug) or in the console (pry).

[1]: https://github.com/ruby/debug/