### PR TITLE
chore: Remove retry_on for ActiveRecord::Deadlocked in ApplicationJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,8 +3,6 @@ class ApplicationJob < ActiveJob::Base
 
   queue_as :background
 
-  retry_on ActiveRecord::Deadlocked
-
   # Most jobs are safe to ignore if the underlying records are no longer available
   discard_on ActiveJob::DeserializationError, ActiveRecord::RecordNotFound
 


### PR DESCRIPTION
- This line is muted by default
- It could be the cause of endlessly running jobs