### PR TITLE
feat: Improve compliance rate and auditor search

### DIFF
--- a/app/models/checks/analyze_accessibility_page.rb
+++ b/app/models/checks/analyze_accessibility_page.rb
@@ -58,6 +58,8 @@ module Checks
 
         return date
       end
+
+      nil
     end
 
     def find_audit_date(pattern)
@@ -70,12 +72,11 @@ module Checks
       extracted_text << page.text(between_headings: [:previous, "État de conformité"])
 
       extracted_text = extracted_text.compact.join(" ")
-      matches = extracted_text.scan(pattern).presence
-      date = extract_date(matches)
+      matches = extracted_text.scan(pattern)
 
-      return date if date
+      return nil if matches.blank?
 
-      nil
+      extract_date(matches)
     end
 
     def find_compliance_rate

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
       "réalisée 1er février 2024" => Date.new(2024, 2, 1),
       "en mars 2024" => Date.new(2024, 3, 1),
       "loi n° 2005-102 du 11 février 2005… audit réalisé le 11 février 2025" => Date.new(2025, 2, 11),
+      "loi n° 2005-102 du 11 février 2005…" => nil,
       "du 15 février 2024" => Date.new(2024, 2, 15),
       "Cette déclaration a été établie le 1er janvier 2024, et mise à jour le 10 avril 2024" => Date.new(2024, 1, 1),
       "Cette déclaration a été établie le 3 juin 2020. Elle a été mise à jour le 4 novembre 2024." => Date.new(2020, 6, 3),


### PR DESCRIPTION
- Enhance `find_compliance_rate` to handle multiple rate matches and prioritize the latest.
- Scope auditor extraction and compliance rate to heading section to improve accuracy.
- Handle the search returning nil if there is only law date present in the text