### PR TITLE
feat: Stream CSV export for sites

### DIFF
--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -23,41 +23,41 @@ class SiteCsvExport
     "sites_#{I18n.l(Time.zone.now, format: :file)}.csv"
   end
 
-  def self.generate(sites)
-    CSV.generate(col_sep: COL_SEP, headers: true) do |csv|
-      csv << HEADERS
+  def self.stream_csv_to(output_stream, sites)
+    output_stream.write CSV.generate_line(HEADERS, col_sep: COL_SEP)
 
-      sites.find_each do |site|
-        audit = site.audit
+    sites.find_each(batch_size: 500) do |site|
+      audit = site.audit
 
-        reachable = audit&.reachable
-        language = audit&.language_indication
-        mention = audit&.accessibility_mention
-        find_accessibility = audit&.find_accessibility_page
-        analyze_accessibility = audit&.analyze_accessibility_page
-        schema = audit&.analyze_schema
-        plan = audit&.analyze_plan
-        heading = audit&.accessibility_page_heading
-        axe = audit&.run_axe_on_homepage
+      reachable = audit&.reachable
+      language = audit&.language_indication
+      mention = audit&.accessibility_mention
+      find_accessibility = audit&.find_accessibility_page
+      analyze_accessibility = audit&.analyze_accessibility_page
+      schema = audit&.analyze_schema
+      plan = audit&.analyze_plan
+      heading = audit&.accessibility_page_heading
+      axe = audit&.run_axe_on_homepage
 
-        csv << [
-          site.url_without_scheme_and_www,
-          site.url,
-          site.tags_list,
-          audit&.checked_at,
-          reachable&.completed?.to_s,
-          extract_value(language, language&.indication),
-          extract_value(mention, mention&.mention_text),
-          extract_value(find_accessibility, find_accessibility&.url),
-          extract_value(analyze_accessibility, analyze_accessibility&.human_compliance_rate),
-          extract_value(analyze_accessibility, analyze_accessibility&.audit_date),
-          extract_value(analyze_accessibility, analyze_accessibility&.audit_update_date),
-          extract_value(schema, link_or_found(schema, "analyze_schema.schema_in_main_text")),
-          extract_value(plan, link_or_found(plan, "analyze_plan.plan_in_main_text")),
-          extract_value(heading, heading&.human_success_rate),
-          extract_value(axe, axe&.human_success_rate),
-        ]
-      end
+      row = [
+        site.url_without_scheme_and_www,
+        site.url,
+        site.tags_list,
+        audit&.checked_at,
+        reachable&.completed?.to_s,
+        extract_value(language, language&.indication),
+        extract_value(mention, mention&.mention_text),
+        extract_value(find_accessibility, find_accessibility&.url),
+        extract_value(analyze_accessibility, analyze_accessibility&.human_compliance_rate),
+        extract_value(analyze_accessibility, analyze_accessibility&.audit_date),
+        extract_value(analyze_accessibility, analyze_accessibility&.audit_update_date),
+        extract_value(schema, link_or_found(schema, "analyze_schema.schema_in_main_text")),
+        extract_value(plan, link_or_found(plan, "analyze_plan.plan_in_main_text")),
+        extract_value(heading, heading&.human_success_rate),
+        extract_value(axe, axe&.human_success_rate),
+      ]
+
+      output_stream.write CSV.generate_line(row, col_sep: COL_SEP)
     end
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,8 +7,8 @@ class Site < ApplicationRecord
   has_many :tags, -> { in_alphabetical_order }, through: :site_tags
   accepts_nested_attributes_for :tags, reject_if: :all_blank
 
-  scope :with_current_audit, -> { joins(:audits).merge(Audit.current.with_check_transitions) }
-  scope :preloaded, -> { with_current_audit.includes(:tags, audits: :checks) }
+  scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
+  scope :preloaded, -> { with_current_audit.includes(:tags, audits: { checks: :check_transitions }) }
 
   after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
 

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -14,6 +14,29 @@ RSpec.describe "Sites" do
 
       expect(response).to have_http_status(:ok)
     end
+
+    context "when requesting CSV format" do
+      subject(:get_csv) { get sites_path(format: :csv) }
+
+      let!(:site) { create(:site, :checked, team:) }
+
+      it "returns CSV content" do
+        get_csv
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("text/csv")
+        expect(response.headers["Content-Disposition"]).to include("attachment")
+        expect(response.headers["Content-Disposition"]).to include("sites_")
+      end
+
+      it "includes site data in CSV" do
+        get_csv
+
+        csv = CSV.parse(response.body, col_sep: ";", headers: true)
+        expect(csv.count).to eq(1)
+        expect(csv.first[Audit.human(:site_url_address)]).to eq(site.url_without_scheme_and_www)
+      end
+    end
   end
 
   describe "GET /sites/:id" do


### PR DESCRIPTION
- Replace in-memory CSV generation with streaming for improved performance.
- Refactor `SiteCsvExport` to support streaming.
- Add `ActionController::Live` for real-time CSV delivery.