### PR TITLE
feat: Refactor FetchResourcesJob with ActiveJob::Continuable

### DIFF
--- a/app/jobs/fetch_resources_job.rb
+++ b/app/jobs/fetch_resources_job.rb
@@ -1,21 +1,25 @@
 class FetchResourcesJob < ApplicationJob
+  include ActiveJob::Continuable
+
   queue_as :slow
 
   rescue_from(Ferrum::StatusError, Ferrum::TimeoutError) do |exception|
     Rails.logger.debug("Failed to fetch SOME home page HTML because: #{exception}")
   end
 
-  # sometimes the underlying Chrome process is [defunct], as show when
-  # inspecting the jobs container with `ps -ef`: it hasn't been killed
-  # properly so SolidQueue has to wait and timeout the job on
-  # Ferrum::ProcessTimeoutError. Failing the job seems to get rid of
-  # the defunct process, so maybe killing the corresponding thread
-  # (within the process) is enough to clear up the process.
-  retry_on Ferrum::ProcessTimeoutError
-
   def perform(audit)
-    FetchHomePageService.call(audit)
-    FindAccessibilityPageService.call(audit)
+    step :start do
+      Rails.logger.info("Started for #{audit.url}")
+    end
+
+    step :fetch_home_page do
+      FetchHomePageService.call(audit)
+    end
+
+    step :find_accessibility_page do
+      FindAccessibilityPageService.call(audit)
+    end
+
   ensure
     ProcessAuditJob.perform_later(audit)
   end


### PR DESCRIPTION
- Add `ActiveJob::Continuable` for improved job handling.
- Remove `retry_on Ferrum::ProcessTimeoutError` to simplify error handling.