### PR TITLE
chore: Optimize CSV export

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -7,11 +7,11 @@ class SitesController < ApplicationController
   # GET /sites
   def index
     params[:sort] ||= { checked_at: :desc }
-    @sites = current_user.sites.preloaded
+    @sites = current_user.sites
     @tags = current_user.team.tags.in_alphabetical_order
     respond_to do |format|
       format.html do
-        @pagy, @sites = pagy @sites.filter_by(params).order_by(params), limit: pagy_limit
+        @pagy, @sites = pagy @sites.preloaded.filter_by(params).order_by(params), limit: pagy_limit
       end
       format.csv do
         set_csv_headers

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -30,42 +30,44 @@ class SiteCsvExport
   def self.stream_csv_to(output_stream, sites)
     output_stream.write CSV.generate_line(HEADERS, col_sep: COL_SEP)
 
-    sites.each do |site|
-      audit = site.audit
+    sites.in_batches(of: 200) do |batch|
+      batch.preloaded.each do |site|
+        audit = site.audit
 
-      reachable = audit&.reachable
-      language = audit&.language_indication
-      mention = audit&.accessibility_mention
-      find_accessibility = audit&.find_accessibility_page
-      analyze_accessibility = audit&.analyze_accessibility_page
-      schema = audit&.analyze_schema
-      plan = audit&.analyze_plan
-      heading = audit&.accessibility_page_heading
-      axe = audit&.run_axe_on_homepage
+        reachable = audit&.reachable
+        language = audit&.language_indication
+        mention = audit&.accessibility_mention
+        find_accessibility = audit&.find_accessibility_page
+        analyze_accessibility = audit&.analyze_accessibility_page
+        schema = audit&.analyze_schema
+        plan = audit&.analyze_plan
+        heading = audit&.accessibility_page_heading
+        axe = audit&.run_axe_on_homepage
 
-      row = [
-        site.url_without_scheme_and_www,
-        site.url,
-        audit.reachable.redirect_url,
-        site.tags_list,
-        audit&.checked_at,
-        reachable&.completed?.to_s,
-        extract_value(language, language&.indication),
-        extract_value(mention, mention&.mention_text),
-        extract_value(find_accessibility, find_accessibility&.url),
-        extract_value(analyze_accessibility, analyze_accessibility&.auditor),
-        extract_value(analyze_accessibility, analyze_accessibility&.human_compliance_rate),
-        extract_value(analyze_accessibility, analyze_accessibility&.audit_date),
-        extract_value(analyze_accessibility, analyze_accessibility&.audit_update_date),
-        extract_value(schema, link_or_found(schema, "analyze_schema.schema_in_main_text")),
-        extract_value(schema, schema&.years&.join("-")),
-        extract_value(plan, link_or_found(plan, "analyze_plan.plan_in_main_text")),
-        extract_value(plan, plan&.years&.join("-")),
-        extract_value(heading, heading&.human_success_rate),
-        extract_value(axe, axe&.human_success_rate),
-      ]
+        row = [
+          site.url_without_scheme_and_www,
+          site.url,
+          audit.reachable.redirect_url,
+          site.tags_list,
+          audit&.checked_at,
+          reachable&.completed?.to_s,
+          extract_value(language, language&.indication),
+          extract_value(mention, mention&.mention_text),
+          extract_value(find_accessibility, find_accessibility&.url),
+          extract_value(analyze_accessibility, analyze_accessibility&.auditor),
+          extract_value(analyze_accessibility, analyze_accessibility&.human_compliance_rate),
+          extract_value(analyze_accessibility, analyze_accessibility&.audit_date),
+          extract_value(analyze_accessibility, analyze_accessibility&.audit_update_date),
+          extract_value(schema, link_or_found(schema, "analyze_schema.schema_in_main_text")),
+          extract_value(schema, schema&.years&.join("-")),
+          extract_value(plan, link_or_found(plan, "analyze_plan.plan_in_main_text")),
+          extract_value(plan, plan&.years&.join("-")),
+          extract_value(heading, heading&.human_success_rate),
+          extract_value(axe, axe&.human_success_rate),
+        ]
 
-      output_stream.write CSV.generate_line(row, col_sep: COL_SEP)
+        output_stream.write CSV.generate_line(row, col_sep: COL_SEP)
+      end
     end
   end
 


### PR DESCRIPTION
- `find_each` on its own was probably a regression because it does not preserve eager loading
- `each` cannot handle massive datasets
- Applying the `preloaded` scope on batches should enhance the performances