### PR TITLE
fix: Wait for page to load

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -11,7 +11,7 @@ class Browser
   ].freeze
   SUCCESS_CODE = 200
   CHROME_VERSIONS = (101..134).to_a.freeze
-  MACOS_VERSIONS = ["10_15_7", "13_4_1", "13_6_6", "14_1_2", "14_7_1", "14_7_3", "15_1_1"].freeze
+  MACOS_VERSIONS = %w[10_15_7 13_4_1 13_6_6 14_1_2 14_7_1 14_7_3 15_1_1].freeze
 
   HEADERS = {
     "Accept" => "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
@@ -30,25 +30,24 @@ class Browser
   }.freeze
 
   BLOCKED_EXTENSIONS = [
-    FONTS = [".woff", ".woff2", ".ttf", ".otf", ".eot"],
-    VIDEOS = [".mp4", ".avi", ".mov", ".mkv", ".webm"],
-    AUDIO = [".mp3", ".ogg", ".wav", ".aac", ".flac"],
-    IMAGES = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".avif"]
+    FONTS = %w[.woff .woff2 .ttf .otf .eot],
+    VIDEOS = %w[.mp4 .avi .mov .mkv .webm],
+    AUDIO = %w[.mp3 .ogg .wav .aac .flac],
+    IMAGES = %w[.jpg .jpeg .png .gif .bmp .svg .webp .avif]
   ].flatten.then { |extensions| Regexp.new("(#{Regexp.union(extensions).source})(?:\\?.*|#.*)?$") }
 
-  BLOCKED_DOMAINS = [
-    "google-analytics.com",
-    "googletagmanager.com",
-    "facebook.net",
-    "facebook.com",
-    "twitter.com",
-    "linkedin.com",
-    "doubleclick.net",
-    "adservice.google.com",
-    "youtube.com",
-    "play.google.com",
-    "sites.statistiques.online",
-    "googleapis.com",
+  BLOCKED_DOMAINS = %w[
+    google-analytics.com
+    googletagmanager.com
+    facebook.net
+    facebook.com
+    twitter.com
+    linkedin.com
+    doubleclick.net
+    adservice.google.com
+    youtube.com play.google.com
+    sites.statistiques.online
+    googleapis.com
   ].then { |domains| Regexp.union(domains) }
 
   class << self
@@ -92,41 +91,43 @@ class Browser
 
     def settings
       @settings ||= begin
-                      {
-                        headless: :new,
-                        timeout: PAGE_TIMEOUT,
-                        window_size: WINDOW_SIZES.sample,
-                        process_timeout: PROCESS_TIMEOUT,
-                        pending_connection_errors: false,
-                        extensions: [Rails.root.join("vendor/javascript/stealth.min.js")],
-                        browser_options: {
-                          "disable-blink-features": "AutomationControlled",
-                          "disable-popup-blocking": true,
-                          "disable-notifications": true,
-                          "no-sandbox" => nil,
-                          "disable-gpu" => nil,
-                          "disable-dev-shm-usage" => nil,
-                          "disable-background-timer-throttling" => nil,
-                          "disable-backgrounding-occluded-windows" => nil,
-                          "disable-renderer-backgrounding" => nil,
-                          "disable-features" => "TranslateUI,VizDisplayCompositor",
-                          "disable-extensions" => nil,
-                          "disable-plugins" => nil,
-                          "disable-default-apps" => nil,
-                          "user-data-dir" => (@user_data_dir = "/tmp/chrome-#{SecureRandom.hex(8)}"),
-                          "remote-debugging-port" => (9222 + Random.rand(1000)).to_s
-                        }
-                      }.tap do |options|
-                        options[:browser_path] = ENV["GOOGLE_CHROME_SHIM"] if Rails.env.production?
-                        options[:proxy] = Rails.application.credentials.proxy if Rails.env.production?
-                        options[:browser_options].merge!("no-sandbox" => nil) if ENV["WITHIN_DOCKER"].present?
-                      end.freeze
-                    end
+        {
+          headless: :new,
+          timeout: PAGE_TIMEOUT,
+          window_size: WINDOW_SIZES.sample,
+          process_timeout: PROCESS_TIMEOUT,
+          pending_connection_errors: false,
+          extensions: [Rails.root.join("vendor/javascript/stealth.min.js")],
+          browser_options: {
+            "disable-blink-features": "AutomationControlled",
+            "disable-popup-blocking": true,
+            "disable-notifications": true,
+            "no-sandbox" => nil,
+            "disable-gpu" => nil,
+            "disable-dev-shm-usage" => nil,
+            "disable-background-timer-throttling" => nil,
+            "disable-backgrounding-occluded-windows" => nil,
+            "disable-renderer-backgrounding" => nil,
+            "disable-features" => "TranslateUI,VizDisplayCompositor",
+            "disable-extensions" => nil,
+            "disable-plugins" => nil,
+            "disable-default-apps" => nil,
+            "user-data-dir" => (@user_data_dir = "/tmp/chrome-#{SecureRandom.hex(8)}"),
+            "remote-debugging-port" => (9222 + Random.rand(1000)).to_s
+          }
+        }.tap do |options|
+          options[:browser_path] = ENV["GOOGLE_CHROME_SHIM"] if Rails.env.production?
+          options[:proxy] = Rails.application.credentials.proxy if Rails.env.production?
+          options[:browser_options].merge!("no-sandbox" => nil) if ENV["WITHIN_DOCKER"].present?
+        end.freeze
+      end
     end
 
     def get(url)
       with_page do |page|
         page.go_to(url)
+        sleep 0.5
+        page.network.wait_for_idle(timeout: PAGE_TIMEOUT.to_f)
         {
           body: page.body,
           status: page.network.status,
@@ -160,8 +161,6 @@ class Browser
     end
 
     def with_page
-      page = nil
-
       begin
         page = create_page
         yield(page)
@@ -173,8 +172,7 @@ class Browser
     def create_page
       browser.create_page.tap do |page|
         page.headers.set(request_headers)
-        page.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
-        page.network.wait_for_idle(timeout: PAGE_TIMEOUT)
+        page.network.blacklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
       end
     end
   end

--- a/spec/models/browser_spec.rb
+++ b/spec/models/browser_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe Browser do
     allow(browser_double).to receive(:quit)
 
     allow(headers_double).to receive(:set)
-    allow(network_double).to receive(:blocklist=)
+    allow(network_double).to receive(:blacklist=)
     allow(network_double).to receive(:wait_for_idle)
     allow(network_double).to receive_messages(status: 200, response: response_double)
     allow(response_double).to receive(:content_type).and_return("text/html")
 
+    allow(page_double).to receive(:at_css)
     allow(page_double).to receive(:go_to).with(url)
     allow(page_double).to receive_messages(headers: headers_double, network: network_double, body: "<html><body>Test</body></html>", current_url: url)
     allow(page_double).to receive(:close)
@@ -174,6 +175,12 @@ RSpec.describe Browser do
       expect(get_result).not_to be_nil
     end
 
+    it "waits for network idle" do
+      get_result
+
+      expect(network_double).to have_received(:wait_for_idle).with(timeout: Browser::PAGE_TIMEOUT)
+    end
+
     it "returns response data hash" do
       result = get_result
 
@@ -233,9 +240,9 @@ RSpec.describe Browser do
       expect(result).to eq(page_double)
     end
 
-    it "sets the blocklist on the page's context" do
+    it "sets the blacklist on the page's context" do
       expect(network_double)
-        .to receive(:blocklist=)
+        .to receive(:blacklist=)
               .with([described_class::BLOCKED_EXTENSIONS, described_class::BLOCKED_DOMAINS])
 
       described_class.send(:create_page)
@@ -248,12 +255,6 @@ RSpec.describe Browser do
       described_class.send(:create_page)
 
       expect(headers_double).to have_received(:set).with(request_headers)
-    end
-
-    it "waits for network idle" do
-      described_class.send(:create_page)
-
-      expect(network_double).to have_received(:wait_for_idle).with(timeout: Browser::PAGE_TIMEOUT)
     end
   end
 end

--- a/spec/models/checks/run_axe_on_homepage_spec.rb
+++ b/spec/models/checks/run_axe_on_homepage_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Checks::RunAxeOnHomepage do
       allow(browser_instance).to receive(:quit)
 
       allow(headers_double).to receive(:set)
-      allow(network_double).to receive(:blocklist=)
+      allow(network_double).to receive(:blacklist=)
       allow(network_double).to receive(:wait_for_idle)
 
       allow(page_instance).to receive(:content=)


### PR DESCRIPTION
- `page.network.wait_for_idle` call was made before the `go_to` resulting in not working properly
- `timeout` was passed as a `ActiveSupport::Duration` but Ferrum expects a float.
- Now we are waiting a bit more with sleep and even if SPAs / redirections are still problematic since we don't know when the page is containing the final content, it's better.
- Sleep in scrapping logic seems natural to me, especially if it's low duration just right before getting the content. WDYT @freesteph ?
