### PR TITLE
feat: Remove `current` from audits

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -35,8 +35,10 @@ class SitesController < ApplicationController
   # POST /sites
   def create
     url = site_params[:url]
+    attributes = site_params.except(:url)
     @site = current_user.team.sites.find_by_url(url:) || current_user.team.sites.build
-    @site.assign_attributes(site_params)
+    @site.assign_attributes(attributes)
+    @site.audits.build(url:)
     notice = t(@site.new_record? ? ".created" : ".new_audit")
     if @site.save
       redirect_to @site, notice:
@@ -57,7 +59,7 @@ class SitesController < ApplicationController
 
   # PATCH/PUT /sites/1
   def update
-    if @site.update(site_params)
+    if @site.update(site_params.except(:url))
       redirect_to @site, notice: t(".notice"), status: :see_other
     else
       render :edit, status: :unprocessable_content
@@ -95,6 +97,7 @@ class SitesController < ApplicationController
   def sites_scope
     current_user.team.sites
   end
+
   def set_site
     @site = sites_scope.preloaded.friendly.find(params.expect(:id))
   end
@@ -102,7 +105,6 @@ class SitesController < ApplicationController
   def set_sites
     @sites = sites_scope
   end
-
 
   def set_bulk_sites
     ids = params.expect(id: [])

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -2,6 +2,7 @@ class Audit < ApplicationRecord
   belongs_to :site, counter_cache: true
   has_many :checks, -> { prioritized }, dependent: :destroy
 
+  after_create :update_site_slug!
   after_create_commit :fetch_resources!, :create_checks
 
   validates :url, presence: true, url: true
@@ -10,7 +11,6 @@ class Audit < ApplicationRecord
   scope :sort_by_newest, -> { order(created_at: :desc) }
   scope :sort_by_url, -> { order(Arel.sql("REGEXP_REPLACE(audits.url, '^https?://(www\.)?', '') ASC")) }
   scope :completed, -> { where.not(completed_at: nil) }
-  scope :current, -> { where(current: true) }
   scope :with_check_transitions, -> { includes(checks: :check_transitions) }
 
   Check.types.each do |name, klass|
@@ -72,7 +72,6 @@ class Audit < ApplicationRecord
   def after_check_completed
     if complete?
       update!(completed_at: Time.zone.now)
-      site.set_current_audit!
     else
       ProcessAuditJob.perform_later(self)
     end
@@ -123,5 +122,9 @@ class Audit < ApplicationRecord
     when :home then home_page_html
     when :accessibility then accessibility_page_html
     end
+  end
+
+  def update_site_slug!
+    site.update_slug!
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,10 +7,7 @@ class Site < ApplicationRecord
   has_many :tags, -> { in_alphabetical_order }, through: :site_tags
   accepts_nested_attributes_for :tags, reject_if: :all_blank
 
-  scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
-  scope :preloaded, -> { with_current_audit.includes(:tags, :slugs, audits: { checks: :check_transitions }) }
-
-  after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
+  scope :preloaded, -> { includes(:tags, :slugs, audits: { checks: :check_transitions }) }
 
   friendly_id :url_without_scheme_and_www, use: [:slugged, :history, :scoped], scope: :team_id
 
@@ -31,19 +28,8 @@ class Site < ApplicationRecord
     end
   end
 
-  def url=(new_url)
-    return if url == new_url
-
-    if audit.pending?
-      audit.url = new_url
-      audit.save if audit.persisted?
-    else
-      audits.build(url: new_url)
-    end
-  end
-
   def url_without_scheme_and_www
-    Link.url_without_scheme_and_www(audit.url)
+    Link.url_without_scheme_and_www(audit&.url)
   end
 
   def name_with_fallback
@@ -68,25 +54,11 @@ class Site < ApplicationRecord
   end
 
   def audit
-    audits.find(&:current?) || audits.current.last || audits.first || audits.build(current: true)
+    audits.find(&:new_record?) || audits.sort_by_newest.first
   end
 
   def audit!
-    audits.create!(url:, current: audits.current.none? || audits.none?)
-  end
-
-  def actual_current_audit
-    audits.completed.sort_by_newest.first || audits.sort_by_newest.first
-  end
-
-  def set_current_audit!
-    return if actual_current_audit && audit == actual_current_audit
-
-    transaction do
-      audit&.update!(current: false)
-      actual_current_audit&.update!(current: true)
-      update_slug!
-    end
+    audits.create!(url:)
   end
 
   def tags_list

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -38,7 +38,11 @@ class SiteUpload
     parse_sites
 
     transaction do
-      create!(new_sites.values) if new_sites.any?
+      new_sites.values.each do |attributes|
+        url = attributes.delete(:url)
+        site = create!(attributes)
+        site.audits.create!(url:)
+      end
       existing_sites.values.each { |site| site.save && site.audit! }
     end
     true

--- a/app/queries/site_query.rb
+++ b/app/queries/site_query.rb
@@ -3,16 +3,19 @@ class SiteQuery < SimpleDelegator
     directions = [:asc, :desc]
     key, direction = params[:sort]&.to_unsafe_h&.first
     direction = direction.to_s.downcase.to_sym.presence_in(directions) || directions.first
+    latest_audits = Audit
+      .select("DISTINCT ON (audits.site_id) audits.*")
+      .order(Arel.sql("audits.site_id, audits.created_at DESC"))
     case key
     in "url"
-      sortable_url = Arel.sql("REGEXP_REPLACE(audits.url, '^https?://(www\.)?', '')")
-      subquery = model.with_current_audit
+      sortable_url = Arel.sql("REGEXP_REPLACE(latest_audits.url, '^https?://(www\.)?', '')")
+      subquery = model.joins("INNER JOIN (#{latest_audits.to_sql}) latest_audits ON latest_audits.site_id = sites.id")
                       .select("sites.*, #{sortable_url} as sortable_url")
                       .order(Arel.sql("sortable_url #{direction}"))
       from(subquery, :sites).order(Arel.sql("sortable_url #{direction}"))
     else
-      subquery = model.with_current_audit
-                      .select("sites.*, audits.completed_at AS last_completed_at")
+      subquery = model.joins("INNER JOIN (#{latest_audits.to_sql}) latest_audits ON latest_audits.site_id = sites.id")
+                      .select("sites.*, latest_audits.completed_at AS last_completed_at")
                       .order(Arel.sql("last_completed_at #{direction} NULLS LAST"))
       from(subquery, :sites).order(Arel.sql("last_completed_at #{direction} NULLS LAST, sites.created_at #{direction}"))
     end

--- a/db/migrate/20260129141721_remove_current_from_audit.rb
+++ b/db/migrate/20260129141721_remove_current_from_audit.rb
@@ -1,0 +1,6 @@
+class RemoveCurrentFromAudit < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :audits, name: "index_audits_on_site_id_and_current"
+    remove_column :audits, :current, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_27_092803) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_29_141721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,14 +19,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_27_092803) do
     t.string "accessibility_page_url"
     t.datetime "completed_at"
     t.datetime "created_at", null: false
-    t.boolean "current", default: false, null: false
     t.text "home_page_html"
     t.string "home_page_url"
     t.bigint "site_id", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
-    t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"
     t.index ["url"], name: "index_audits_on_url"
   end

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -9,10 +9,6 @@ FactoryBot.define do
       end
     end
 
-    trait :current do
-      current { true }
-    end
-
     trait :completed do
       completed_at { 1.day.ago }
     end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     trait :completed do
       after(:create) do |site|
-        audit = site.audits.current.first || create(:audit, :current, site:, url: site.url)
+        audit = site.audits.first || create(:audit, site:, url: site.url)
         audit.update!(completed_at: 1.day.ago)
       end
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -93,87 +93,9 @@ RSpec.describe Site do
       new_url = "https://new-example.com"
 
       create(:audit, :completed, site:, url: new_url)
-      site.set_current_audit!
 
       expect(site.reload.slug).to eq("new-example-com")
       expect(described_class.friendly.find(old_slug)).to eq(site)
-    end
-  end
-
-  describe "#actual_current_audit" do
-    subject(:site) { create(:site) }
-
-    context "with a freshly created site" do
-      it "returns the initial audit" do
-        expect(site.actual_current_audit).to eq(site.audits.first)
-      end
-    end
-
-    context "when there are completed audits" do
-      let!(:old_audit) { create(:audit, :completed, site:, completed_at: 2.days.ago) }
-      let!(:newest_audit) { create(:audit, :completed, site:, completed_at: 1.day.ago) }
-
-      it "returns the newest completed audit" do
-        expect(site.reload.actual_current_audit).to eq(newest_audit)
-      end
-    end
-
-    context "when initial audit is incomplete but other audits are completed" do
-      let!(:completed_audit) { create(:audit, :completed, site:, completed_at: 1.day.ago) }
-
-      it "returns the completed audit" do
-        expect(site.actual_current_audit).to eq(completed_audit)
-      end
-    end
-
-    context "when no audits are completed" do
-      let!(:newer_audit) { create(:audit, site:, completed_at: nil, created_at: 1.day.from_now) }
-
-      it "returns the newest audit by creation date" do
-        expect(site.actual_current_audit).to eq(newer_audit)
-      end
-    end
-  end
-
-  describe "#set_current_audit!" do
-    subject(:site) { create(:site) }
-
-    let(:initial_audit) { site.audits.first }
-
-    context "when there are multiple audits" do
-      subject(:site) { create(:site) }
-
-      it "marks the newest audit as current" do
-        old_audit = site.audit
-        newest_audit = create(:audit, site:, completed_at: 1.day.ago)
-        expect { site.set_current_audit! }.to change { newest_audit.reload.current }.from(false).to(true)
-          .and change { old_audit.reload.current }.from(true).to(false)
-      end
-    end
-
-    context "when the actual current audit is already marked as current" do
-      it "does not change anything" do
-        initial_audit.update(current: true)
-        expect { site.set_current_audit! }.not_to change { initial_audit.reload.current }
-      end
-    end
-
-    context "when there are incomplete audits only" do
-      let!(:newest_audit) { create(:audit, site:, completed_at: nil, created_at: 1.day.from_now) }
-
-      it "marks the newest audit as current" do
-        expect { site.set_current_audit! }.to change { newest_audit.reload.current }.from(false).to(true)
-      end
-    end
-
-    context "when there are both completed and incomplete audits" do
-      let!(:newest_completed_audit) { create(:audit, :completed, site:, completed_at: 2.days.ago) }
-      let!(:newest_incomplete_audit) { create(:audit, site:, completed_at: nil, created_at: 1.day.from_now) }
-
-      it "marks the newest completed audit as current" do
-        expect { site.set_current_audit! }.to change { newest_completed_audit.reload.current }.from(false).to(true)
-        expect(newest_incomplete_audit.reload.current).to be false
-      end
     end
   end
 end

--- a/spec/queries/site_query_spec.rb
+++ b/spec/queries/site_query_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe SiteQuery do
     subject(:result) { query.order_by(params) }
 
     context "when ordering by url" do
-      let!(:apple) { create(:audit, :current, url: "https://apple.com") }
-      let!(:app) { create(:audit, :current, url: "http://www.app.apple.com") }
-      let!(:banana) { create(:audit, :current, url: "https://www.banana.org") }
-      let!(:blog) { create(:audit, :current, url: "http://blog.beta.com") }
-      let!(:carrot) { create(:audit, :current, url: "https://carrot.bio") }
+      let!(:apple) { create(:audit, url: "https://apple.com") }
+      let!(:app) { create(:audit, url: "http://www.app.apple.com") }
+      let!(:banana) { create(:audit, url: "https://www.banana.org") }
+      let!(:blog) { create(:audit, url: "http://blog.beta.com") }
+      let!(:carrot) { create(:audit, url: "https://carrot.bio") }
 
       let(:expected_ids) do
         [
@@ -35,7 +35,7 @@ RSpec.describe SiteQuery do
         it "handles multiple different URLs for the same site" do
           create(:audit, site: apple.site, url: "https://support.apple.com")
 
-          expect(result.ids).to eq(expected_ids)
+          expect(result.ids).to eq([app.site_id, banana.site_id, blog.site_id, carrot.site_id, apple.site_id])
         end
       end
 
@@ -52,9 +52,9 @@ RSpec.describe SiteQuery do
       let(:request) { {} }
       let(:expected_ids) { [audit3.site_id, audit2.site_id, audit1.site_id] }
 
-      let!(:audit1) { create(:audit, :current, completed_at: 1.day.ago) }
-      let!(:audit2) { create(:audit, :current, completed_at: 2.days.ago) }
-      let!(:audit3) { create(:audit, :current, completed_at: 3.days.ago) }
+      let!(:audit1) { create(:audit, completed_at: 1.day.ago) }
+      let!(:audit2) { create(:audit, completed_at: 2.days.ago) }
+      let!(:audit3) { create(:audit, completed_at: 3.days.ago) }
 
       it "sorts by latest audit completion date in descending order" do
         expect(result.ids).to eq(expected_ids)
@@ -64,9 +64,9 @@ RSpec.describe SiteQuery do
     context "when sort[completed_at]=desc" do
       let(:request) { { sort: { completed_at: :desc } } }
 
-      let!(:audit1) { create(:audit, :current, completed_at: 1.day.ago) }
-      let!(:audit2) { create(:audit, :current, completed_at: 2.days.ago) }
-      let!(:audit3) { create(:audit, :current, completed_at: 3.days.ago) }
+      let!(:audit1) { create(:audit, completed_at: 1.day.ago) }
+      let!(:audit2) { create(:audit, completed_at: 2.days.ago) }
+      let!(:audit3) { create(:audit, completed_at: 3.days.ago) }
 
       it "sorts by latest audit completion date in descending order" do
         expect(result.ids).to eq([audit1.site_id, audit2.site_id, audit3.site_id])
@@ -77,10 +77,8 @@ RSpec.describe SiteQuery do
         site2 = audit2.site
 
         create(:audit, site: site1, completed_at: 6.hours.ago)
-        site1.set_current_audit!
 
         create(:audit, site: site2, completed_at: 12.hours.ago)
-        site2.set_current_audit!
 
         result = query.where(id: [site1.id, site2.id]).order_by(params)
         expect(result.ids).to eq([site1.id, site2.id])


### PR DESCRIPTION
- Drop the `current` column and associated index from `audits` table.
- Refactor queries, scopes, factories, and specs to remove reliance on `current`.
