### PR TITLE
fix: Crawler logic

### DIFF
--- a/app/models/crawler.rb
+++ b/app/models/crawler.rb
@@ -41,6 +41,7 @@ class Crawler
 
   def get_page
     link = queue.shift
+    return if crawled.include?(link.href)
     return nil unless link
 
     crawled << link


### PR DESCRIPTION
- Prevent re-crawling of already visited links in `Crawler`.
- Improve child link enqueuing by excluding redundant URLs.