### PR TITLE
feat: Improve bulk deletion

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,5 +1,5 @@
 class Check < ApplicationRecord
-  has_many :check_transitions, autosave: false, dependent: :destroy
+  has_many :check_transitions, autosave: false, dependent: :delete_all
 
   include Statesman::Adapters::ActiveRecordQueries[
             transition_class: CheckTransition,

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -8,7 +8,7 @@ class Site < ApplicationRecord
   accepts_nested_attributes_for :tags, reject_if: :all_blank
 
   scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
-  scope :preloaded, -> { with_current_audit.includes(:tags, audits: { checks: :check_transitions }) }
+  scope :preloaded, -> { with_current_audit.includes(:tags, :slugs, audits: { checks: :check_transitions }) }
 
   after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -8,12 +8,12 @@
 </div>
 
 <% form_id = :table_form %>
-<%= form_with(url: sites_path, method: :delete, id: form_id) {} %><%# Form inputs are in every line, associated with the form id %>
+<%= form_with(url: bulk_destroy_sites_path, method: :delete, id: form_id) {} %><%# Form inputs are in every line, associated with the form id %>
 <%= dsfr_table(caption: t('.caption'), border: true) do |t| %>
   <% hidden_fields = flatten_params(:sort, :filter, :limit).except("filter[q]") %>
   <% t.with_search(url: url_for, name: "filter[q]", value: params.dig(:filter, :q), hidden_fields:) %>
   <% t.with_header_action do %>
-    <%= button_tag t("shared.destroy_all"), form: form_id, data: { table_target: :button, turbo_confirm: t("shared.confirm") }, class: icon_class(:delete, line: true, btn: :secondary, class: "fr-hidden") %>
+    <%= button_tag t("shared.destroy_all"), form: form_id, data: { table_target: :button, turbo_confirm: t("shared.confirm"), turbo_submits_with: t(".deleting") }, class: icon_class(:delete, line: true, btn: :secondary, class: "fr-hidden") %>
   <% end %>
   <% t.with_head do %>
     <tr>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -296,7 +296,7 @@ fr:
       new_audit: Site existant, nouvel audit programmé
     destroy:
       notice: Site supprimé
-    destroy_all:
+    bulk_destroy:
       notice:
         one: Un site supprimé
         other: "%{count} sites supprimés"
@@ -310,6 +310,7 @@ fr:
       url_hint: Saisissez une url valide, commençant par https:// ou http://
     index:
       caption: Tous les sites
+      deleting: Suppression…
       detail: Détails
       export_to_csv: Télécharger en CSV
       last_audit_at: Dernière vérification

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     collection do
       post :upload
       get :upload, to: redirect("/sites/new")
-      delete :destroy_all, path: ""
+      delete :bulk_destroy
     end
     resources :audits, only: [:create, :show]
   end

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -116,6 +116,25 @@ RSpec.describe "Sites" do
     end
   end
 
+  describe "DELETE /sites" do
+    subject(:delete_sites) { delete bulk_destroy_sites_path, params: { id: site_ids } }
+
+    let!(:site) { create(:site, team:) }
+    let!(:other_site) { create(:site, team:) }
+    let!(:team_site) { create(:site, team: create(:team)) }
+    let(:site_ids) { [site.id, other_site.id] }
+
+    it "destroys selected sites and redirects to index" do
+      expect { delete_sites }.to change(Site, :count).by(-2)
+
+      expect(Site.exists?(team_site.id)).to be(true)
+      expect(response).to redirect_to(sites_path)
+      expect(response).to have_http_status(:see_other)
+      follow_redirect!
+      expect(flash[:notice]).to be_present
+    end
+  end
+
   describe "POST /sites/upload" do
     subject(:upload_sites) { post upload_sites_path, params: { site_upload: { file: } } }
 


### PR DESCRIPTION
- Use `redirect_back` for `bulk_destroy`
- Use in_batches for more efficient deletions.
- Enhance `preloaded` scope to include `slugs`.