### PR TITLE
feat: Add configurable pagination limits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,9 @@ class ApplicationController < ActionController::Base
   include ErrorHelper
   include ActionView::RecordIdentifier
 
+  DEFAULT_PAGY_LIMIT = 20
+  MAX_PAGY_LIMIT = 100
+
   layout :layout_selector
 
   helper_method :resource, :resource_model
@@ -50,6 +53,9 @@ class ApplicationController < ActionController::Base
   end
 
   def pagy_limit
-    Integer(params[:limit], 10, exception: false).then { it&.nonzero? }
+    limit = params[:limit].to_i
+    limit = DEFAULT_PAGY_LIMIT if limit <= 0
+
+    [limit, MAX_PAGY_LIMIT].min
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,7 +4,7 @@ class TagsController < ApplicationController
 
   # GET /tags
   def index
-    @pagy, @tags = pagy current_user.team.tags.in_alphabetical_order
+    @pagy, @tags = pagy current_user.team.tags.in_alphabetical_order, limit: pagy_limit
   end
 
   # POST /tags
@@ -22,7 +22,7 @@ class TagsController < ApplicationController
 
   # GET /tags/1
   def show
-    @pagy, @sites = pagy @tag.sites
+    @pagy, @sites = pagy @tag.sites, limit: pagy_limit
   end
 
   # GET /tags/1/edit

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -375,9 +375,7 @@ fr:
       new: Nouvelle étiquette
     index:
       caption: Toutes les étiquettes
-      empty:
-        one: Aucune étiquette
-        other: Aucune étiquette
+      empty: Aucune étiquette
       name: Libellé
       see_sites: "Sites avec l'étiquette %{tag} (%{count})"
       sites: Sites


### PR DESCRIPTION
- Update `pagy_limit` method to enforce limits and prevent invalid values.
- Apply new limits to `tags#index` and `tags#show` actions.