### PR TITLE
fix: Check (transitions) creation race condition

### DIFF
--- a/app/jobs/process_audit_job.rb
+++ b/app/jobs/process_audit_job.rb
@@ -7,7 +7,7 @@ class ProcessAuditJob < ApplicationJob
     audit
       .checks
       .remaining
-      .filter { |check| check.transition_to(:ready) }
+      .filter { |check| Statesman::Machine.retry_conflicts { check.transition_to(:ready) } }
       .each { |check| RunCheckJob.set(group: "check_#{check.id}").perform_later(check) }
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -33,20 +33,16 @@ class Audit < ApplicationRecord
     build_page(kind, page_url)
   end
 
-  def all_checks
-    Check.names.map { |name| public_send(name) }
-  end
-
   def check_completed?(identifier)
     send(identifier).completed?
   end
 
   def create_checks
-    all_checks.select(&:new_record?).each(&:save)
+    Check.types.each_value { |klass| checks.create_or_find_by!(type: klass.name) }
   end
 
   def all_check_states
-    all_checks.collect(&:current_state)
+    checks.collect(&:current_state)
   end
 
   def pending?

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -7,14 +7,12 @@ class Check < ApplicationRecord
           ]
 
   def state_machine
-    Statesman::Machine.retry_conflicts do
-      @state_machine ||= CheckStateMachine.new(
-        self,
-        transition_class: CheckTransition,
-        association_name: :check_transitions,
-        initial_transition: persisted?
-      )
-    end
+    @state_machine ||= CheckStateMachine.new(
+      self,
+      transition_class: CheckTransition,
+      association_name: :check_transitions,
+      initial_transition: false
+    )
   end
 
   delegate :current_state,

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -2,7 +2,7 @@
   <%= dsfr_row_check(site) %>
   <td class="fr-cell--center"><%= link_icon(:article, t('.view_name', name: site.name_with_fallback), url_for([site, site.audit]), title: t('.view_name', name: site.name_with_fallback), line: true, side: :left, sr_only: true) %></td>
   <td><%= link_to site.url_without_scheme_and_www.truncate(35, separator: /\W/), site.url, target: :_blank, title: site.url_without_scheme_and_www.length > 35 ? site.url_without_scheme_and_www : nil %></td>
-  <% site.audit.all_checks.each do |check| %>
+  <% site.audit.checks.each do |check| %>
     <td id="<%= dom_id(check, :sites_table) %>" class="fr-cell--center"><%= badge(to_badge(check), tooltip: check.tooltip?) %></td>
   <% end %>
   <td class="fr-cell--multiline">

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -28,7 +28,7 @@
         <%= t("audit.status.#{@audit.status_from_checks}") %>
       </p>
     <% end %>
-    <%= render(partial: @audit.all_checks, as: :check) %>
+    <%= render(partial: @audit.checks, as: :check) %>
   </div>
   <div class="fr-col-12 fr-col-md-4">
     <% audits = @site.audits.sort_by_newest.load %>

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -123,7 +123,7 @@ end
 Alors("la page contient toutes les vérifications du site {string} avec le préfixe {string}") do |url, prefix|
   site = team.sites.find_by_url(url:)
   expect(page).to have_css("table") if prefix.present?
-  site.audit.all_checks.each do |check|
+  site.audit.checks.each do |check|
     expect(page).to have_content(check.class.table_header)
   end
 end
@@ -131,14 +131,14 @@ end
 Alors("la page contient un tableau avec toutes les vérifications du site {string}") do |url|
   site = team.sites.find_by_url(url:)
   expect(page).to have_css("table")
-  site.audit.all_checks.each do |check|
+  site.audit.checks.each do |check|
     expect(page).to have_content(check.table_header)
   end
 end
 
 Alors("la page contient toutes les vérifications du site {string}") do |url|
   site = team.sites.find_by_url(url:)
-  site.audit.all_checks.each do |check|
+  site.audit.checks.each do |check|
     expect(page).to have_content(check.human_type)
   end
 end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -44,25 +44,6 @@ RSpec.describe Audit do
     end
   end
 
-  describe "#all_checks" do
-    subject(:checks) { build(:audit).all_checks }
-
-    it "returns all checks, building missing ones" do
-      expect(checks.size).to eq(Check.types.size)
-      expect(checks.all?(&:new_record?)).to be true
-    end
-
-    it "caches built checks in instance variables" do
-      audit = build(:audit)
-      audit.all_checks
-
-      Check.types.each do |name, klass|
-        expect(audit.instance_variable_get("@#{name}")).to be_present
-        expect(audit.instance_variable_get("@#{name}")).to be_a(klass)
-      end
-    end
-  end
-
   describe "#page" do
     subject(:page) { audit.page(kind) }
 
@@ -197,7 +178,7 @@ RSpec.describe Audit do
   describe "#create_checks" do
     subject(:create_checks) { audit.create_checks }
 
-    let(:audit) { build(:audit) }
+    let(:audit) { create(:audit) }
 
     it "creates all check types" do
       expect { create_checks }.to change(Check, :count).by(Check.types.size)


### PR DESCRIPTION
- Remove `Audit#all_checks` and directly use `Audit#checks` instead of building and not creating checks.
- Move retry_on_conflicts in job where it actually makes sense and where it actually works. This fixes the huge amount of statesman error.