### PR TITLE
chore: Upgrade brakeman to 8.0.4 and remove `--ensure-latest` flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.20.1)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
- Dependencies bumps are packaged in PRs opened by dependabot. Gems are updated (if needed) once a week.
- Enforcing Brakeman latest version is nice, but not if it conflicts with dev workflow.
- Will revert if considered harmful.