### PR TITLE
Fix: Network idle waits

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -92,41 +92,43 @@ class Browser
 
     def settings
       @settings ||= begin
-                      {
-                        headless: :new,
-                        timeout: PAGE_TIMEOUT,
-                        window_size: WINDOW_SIZES.sample,
-                        process_timeout: PROCESS_TIMEOUT,
-                        pending_connection_errors: false,
-                        extensions: [Rails.root.join("vendor/javascript/stealth.min.js")],
-                        browser_options: {
-                          "disable-blink-features": "AutomationControlled",
-                          "disable-popup-blocking": true,
-                          "disable-notifications": true,
-                          "no-sandbox" => nil,
-                          "disable-gpu" => nil,
-                          "disable-dev-shm-usage" => nil,
-                          "disable-background-timer-throttling" => nil,
-                          "disable-backgrounding-occluded-windows" => nil,
-                          "disable-renderer-backgrounding" => nil,
-                          "disable-features" => "TranslateUI,VizDisplayCompositor",
-                          "disable-extensions" => nil,
-                          "disable-plugins" => nil,
-                          "disable-default-apps" => nil,
-                          "user-data-dir" => (@user_data_dir = "/tmp/chrome-#{SecureRandom.hex(8)}"),
-                          "remote-debugging-port" => (9222 + Random.rand(1000)).to_s
-                        }
-                      }.tap do |options|
-                        options[:browser_path] = ENV["GOOGLE_CHROME_SHIM"] if Rails.env.production?
-                        options[:proxy] = Rails.application.credentials.proxy if Rails.env.production?
-                        options[:browser_options].merge!("no-sandbox" => nil) if ENV["WITHIN_DOCKER"].present?
-                      end.freeze
-                    end
+        {
+          headless: :new,
+          timeout: PAGE_TIMEOUT,
+          window_size: WINDOW_SIZES.sample,
+          process_timeout: PROCESS_TIMEOUT,
+          pending_connection_errors: false,
+          extensions: [Rails.root.join("vendor/javascript/stealth.min.js")],
+          browser_options: {
+            "disable-blink-features": "AutomationControlled",
+            "disable-popup-blocking": true,
+            "disable-notifications": true,
+            "no-sandbox" => nil,
+            "disable-gpu" => nil,
+            "disable-dev-shm-usage" => nil,
+            "disable-background-timer-throttling" => nil,
+            "disable-backgrounding-occluded-windows" => nil,
+            "disable-renderer-backgrounding" => nil,
+            "disable-features" => "TranslateUI,VizDisplayCompositor",
+            "disable-extensions" => nil,
+            "disable-plugins" => nil,
+            "disable-default-apps" => nil,
+            "user-data-dir" => (@user_data_dir = "/tmp/chrome-#{SecureRandom.hex(8)}"),
+            "remote-debugging-port" => (9222 + Random.rand(1000)).to_s
+          }
+        }.tap do |options|
+          options[:browser_path] = ENV["GOOGLE_CHROME_SHIM"] if Rails.env.production?
+          options[:proxy] = Rails.application.credentials.proxy if Rails.env.production?
+          options[:browser_options].merge!("no-sandbox" => nil) if ENV["WITHIN_DOCKER"].present?
+        end.freeze
+      end
     end
 
     def get(url)
       with_page do |page|
         page.go_to(url)
+        page.network.wait_for_idle(timeout: PAGE_TIMEOUT)
+
         {
           body: page.body,
           status: page.network.status,
@@ -174,7 +176,6 @@ class Browser
       browser.create_page.tap do |page|
         page.headers.set(request_headers)
         page.network.blocklist = [BLOCKED_EXTENSIONS, BLOCKED_DOMAINS]
-        page.network.wait_for_idle(timeout: PAGE_TIMEOUT)
       end
     end
   end

--- a/spec/models/browser_spec.rb
+++ b/spec/models/browser_spec.rb
@@ -174,6 +174,12 @@ RSpec.describe Browser do
       expect(get_result).not_to be_nil
     end
 
+    it "waits for network idle" do
+      get_result
+
+      expect(network_double).to have_received(:wait_for_idle).with(timeout: Browser::PAGE_TIMEOUT)
+    end
+
     it "returns response data hash" do
       result = get_result
 
@@ -248,12 +254,6 @@ RSpec.describe Browser do
       described_class.send(:create_page)
 
       expect(headers_double).to have_received(:set).with(request_headers)
-    end
-
-    it "waits for network idle" do
-      described_class.send(:create_page)
-
-      expect(network_double).to have_received(:wait_for_idle).with(timeout: Browser::PAGE_TIMEOUT)
     end
   end
 end


### PR DESCRIPTION
- Add `network.wait_for_idle` after page navigation.
- Remove not properly set idle wait inside page creation.

These sites are now properly fetch and their final body are store in DB : 

admin.snu.gouv.fr
app.datasubvention.beta.gouv.fr
app.pix.fr
candidat.pole-emploi.fr/simulation-ressources-formation
carbure.beta.gouv.fr
cartobio.agencebio.org
dossierfacile.fr


