### PR TITLE
chore: Remove unused `broadcasts_refreshes_to`

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -62,8 +62,6 @@ class Check < ApplicationRecord
   scope :remaining, -> { in_state(:pending, :blocked) }
   scope :errored, -> { in_state(:failed) }
 
-  broadcasts_refreshes_to ->(check) { "sites" }
-
   class << self
     def human_type
       I18n.t("checks.#{model_name.element}.type")


### PR DESCRIPTION
- Unused and was still triggering many turbo jobs.
- With it https://www.paris.fr tiggers 26 jobs
- Without it, 14 jobs.