### PR TITLE
chore: Permettre de prévisualiser une page crawlée pour faciliter le débogage

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ bundle exec rubocop
 bundle exec rubocop -a
 ```
 
-## 🔬 Debug
+## 🔬 Outils de debugging
+
+### Debugger
 
 Dans l'environnement Docker, vous pouvez utiliser `debug` pour
 arrêter et explorer votre code à un endroit précis :
@@ -248,3 +250,24 @@ web-1          | DEBUGGER: wait for debugger connection...
 
 ouvrez un terminal et lancez `make debug` qui se connecte
 automatiquement au debugger.
+
+### Prévisualiser une page crawlée
+
+Le script `bin/preview_audit` permet d'ouvrir le HTML crawlé d'un audit dans le navigateur.
+
+```bash
+bin/preview_audit home|accessibility [AUDIT_ID]
+```
+
+- `home` : page d'accueil crawlée
+- `accessibility` : page accessibilité crawlée
+- `AUDIT_ID` : optionnel, utilise le dernier audit si absent
+
+Exemples :
+
+```bash
+bin/preview_audit home 42
+bin/preview_audit accessibility
+```
+
+Le fichier généré est placé dans `tmp/` et le chemin est affiché en sortie.

--- a/bin/preview_audit
+++ b/bin/preview_audit
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+
+PREVIEW_KINDS = %w[home accessibility].freeze
+
+usage = <<~USAGE
+  Usage: bin/preview_audit home|accessibility [AUDIT_ID]
+
+  Examples:
+    bin/preview_audit home 42
+    bin/preview_audit accessibility
+USAGE
+
+def find_audit(audit_id)
+  audit_id ? Audit.find(audit_id) : Audit.last
+end
+
+def html_for(audit, kind)
+  case kind
+  when "home" then audit.home_page_html
+  when "accessibility" then audit.accessibility_page_html
+  end
+end
+
+def create_preview(audit, kind, html)
+  filename = "audit-#{audit.id}-#{kind}.html"
+  container_path = Rails.root.join("tmp", filename)
+  host_root = ENV["HOST_APP_PATH"].presence
+  preview_path = host_root.present? ? Pathname.new(host_root).join("tmp", filename) : container_path
+
+  File.write(container_path, html)
+
+  preview_path
+end
+
+# main
+
+if ARGV.length < 1 || ARGV.length > 2
+  abort usage
+end
+
+kind, audit_id = ARGV
+
+unless PREVIEW_KINDS.include?(kind)
+  abort("Unknown preview kind #{kind.inspect}. Use home or accessibility.\n\n#{usage}")
+end
+
+puts "Start"
+
+audit = find_audit(audit_id)
+abort("No audits found.") if audit.nil?
+
+html = html_for(audit, kind)
+abort("No preview HTML available for '#{kind}' on audit ##{audit.id}.") if html.blank?
+
+preview_path = create_preview(audit, kind, html)
+
+puts "Preview file: #{preview_path}"
+puts "End"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: acces_cible
     environment:
       DATABASE_URL: 'postgresql://postgres:dummy@db:5433'
+      HOST_APP_PATH: ${PWD}
       RUBY_DEBUG_HOST: 0.0.0.0
       RUBY_DEBUG_NO_RELINE: true
       RUBY_DEBUG_PORT: 12345


### PR DESCRIPTION
# #492 
## Contexte
Déboguer le crawler était difficile, car les pages crawlées n'étaient consultables que sous forme de HTML brut dans la console Rails. Il n'était donc pas simple de les ouvrir dans un navigateur ou dans un éditeur pour les inspecter correctement.

## Changement
Cette PR ajoute une commande développeur dédiée pour exporter une page crawlée dans un fichier HTML temporaire.

## Utilisation
Depuis l'environnement de développement :

```bash
bin/preview_audit home 42
bin/preview_audit accessibility 42
bin/preview_audit home  # utilise le dernier audit
```

Le kind est passé en premier argument, AUDIT_ID est optionnel et vaut le dernier audit par défaut.

La commande écrit le snapshot HTML dans tmp/ et affiche le chemin du fichier généré, qui peut ensuite être ouvert dans un navigateur ou un IDE.

Une section dédiée a également été ajoutée dans le README sous "Outils de debugging".