### PR TITLE
fix: Corriger la recherche du taux 

### DIFF
--- a/app/models/checks/analyze_accessibility_page.rb
+++ b/app/models/checks/analyze_accessibility_page.rb
@@ -7,7 +7,7 @@ module Checks
     AUDIT_DATE_PATTERN = /(?<full_date>(?:réalisé(?:e)?(?:\s+le)?|établi(?:e)?(?:\s+le)?|en|du|le|au)\s+(?:(?:(?<day>\d{1,2})(?:\s+|er\s+)?)?(?<month>[a-zéûà]+)\s+(?<year>\d{4})|(?<day_num>\d{1,2})[\/\-\.](?<month_num>\d{1,2})[\/\-\.](?<year_num>\d{4})))/i
     AUDIT_UPDATE_DATE_PATTERN = /(?<full_date>(?:mis(?:e)?\s+à\s+jour(?:\s+le)?|actualisé(?:e)?(?:\s+le)?|modifié(?:e)?(?:\s+le)?)\s+(?:(?:(?<day>\d{1,2})(?:\s+|er\s+)?)?(?<month>[a-zéûà]+)\s+(?<year>\d{4})|(?<day_num>\d{1,2})[\/\-\.](?<month_num>\d{1,2})[\/\-\.](?<year_num>\d{4})))/i
     AUDIT_DATE_KEYWORDS = ["audit", "conformité", "accessibilité", "révèle", "finalisé", "réalisé"].freeze
-    COMPLIANCE_PATTERN = /(?:(?:avec (?:un |une )?)?taux de conformité (?!moyen)|conforme à|révèle que|des crit(?:è|e)res)[^.]*?(\d+(?:[.,]\d+)?)(?:\s*%| pour cent)|(\d{1,3}(?:[.,]\d+)?)\s*%\s*(?:des crit(?:è|e)res(?: RGAA)?(?:\s+sont\s+respect(?:é|e)s)?|au RGAA)/i
+    COMPLIANCE_PATTERN = /(?:(?:avec (?:un |une )?)?taux (?:global )?de conformité (?!moyen)|conforme à|révèle que|mis(?:e)? à jour à|des crit(?:è|e)res)[^.]*?(\d+(?:[.,]\d+)?)(?:\s*%| pour cent)|(\d{1,3}(?:[.,]\d+)?)\s*%\s*(?:des crit(?:è|e)res(?: RGAA)?(?:\s+sont\s+respect(?:é|e)s)?|au RGAA)/i
     STANDARD_PATTERN = /(?:au |des critères )?(?:(RGAA(?:[. ](?:version|v)?[. ]?\d+(?:\.\d+(?:\.\d+)?)?)?|(WCAG)))/i
     AUDITOR_PATTERN = /(?:réalisé(?:e)?\s+par|par|l[’']\s*agence|la\s+société)\s+(?:la\s+société\s+|l[’']\s*agence\s+)?([^,.]+?)(?:,| révèle| sur|\.|$)/i
     UPDATE_AUDIT_PATTERNS = [

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -235,6 +235,7 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
       "le taux de conformité global était de 60,8% [...] le taux de conformité global est de 70,9%." => 70.9,
       "94,03% des critères RGAA sont respectés. Le taux moyen de conformité du service en ligne s’élève à 99%" => 94.03,
       "taux de conformité globale est de 95 pour cent" => 95,
+      "Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% sur l’ensemble critères du référentiel générale d’amélioration de l’accessibilité (RGAA)." => 71.21,
       "Le taux de conformité global est de 74,6 %.
       Le taux de conformité moyen est de 87,4 %.
       Le taux de conformité global est de 83,1 %.


### PR DESCRIPTION
# fix #484 

## Contexte

Sur la page d’accessibilité de Carrefour, le taux de conformité n’était pas extrait.
La regex utilisée pour rechercher le taux ne couvrait pas la formulation :

`Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% ...`

## Changements

- élargissement de la regex d’extraction du taux pour couvrir `taux global de conformité`
- prise en charge de la formulation `mis à jour à ...%`
- ajout d’un cas de test sur le texte Carrefour dans `spec/models/checks/analyze_accessibility_page_spec.rb`

## Résultat attendu

Le taux extrait pour ce cas est désormais `71.21`.