### PR TITLE
fix: DOM parsing for hidden-root accessibility pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,7 +2,7 @@ class Page
   HEADINGS = "h1,h2,h3,h4,h5,h6".freeze
   DOCUMENT_EXTENSIONS = /\.(pdf|zip|odt|ods|odp|doc|docx|xls|xlsx|ppt|pptx)$/i
   FILES_EXTENSIONS = /\.(xml|rss|atom|ics|ical|jpg|jpeg|png|gif|mp3|mp4|avi|mov)$/i
-  INVISIBLE_ELEMENTS = "script, style, noscript, meta, link, iframe[src], [hidden], [style*='display:none'], [style*='display: none'], [style*='visibility:hidden'], [style*='visibility: hidden']".freeze
+  NON_CONTENT_ELEMENTS = "script, style, noscript, meta, link, iframe[src]".freeze
   LINKS_SELECTOR = "a[href]:not([href^='#']):not([href^=mailto]):not([href^=tel])".freeze
   MAIL_TO_SELECTOR = "a[href^=mailto]".freeze
   MAIL_PATTERN = /(?:[a-zA-Z0-9._%+-]+(?:@|\(at\))[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/
@@ -86,12 +86,7 @@ class Page
   end
 
   def dom
-    @dom ||= Nokogiri::HTML(html).tap do |document|
-      document.css(INVISIBLE_ELEMENTS).each(&:remove)
-      document.xpath("//text()[normalize-space(.) != '']").each { |node| node.content = " #{node.content} " }
-    end
-  rescue Nokogiri::SyntaxError => e
-    raise ParseError.new url, e.message
+    @dom ||= parse_html_document
   end
 
   def links(skip_files: true, between_headings: nil)
@@ -136,7 +131,7 @@ class Page
   end
 
   def dom_headings
-    @dom_headings ||= dom.css(HEADINGS)
+    @dom_headings ||= content_dom.css(HEADINGS)
   end
 
   def heading(matcher)
@@ -179,7 +174,7 @@ class Page
   end
 
   def source_for(between_headings: nil)
-    return dom unless between_headings
+    return content_dom unless between_headings
 
     start_matcher, end_matcher = between_headings
     start_node, end_node = find_heading_nodes(start_matcher, end_matcher)
@@ -201,8 +196,21 @@ class Page
       node.ancestors.any? { |ancestor| nodes_between.include?(ancestor) }
     end
 
-    dom.fragment.tap do |fragment|
+    content_dom.fragment.tap do |fragment|
       deduped_nodes.each { |node| fragment.add_child(node.dup) }
     end
+  end
+
+  def content_dom
+    @content_dom ||= parse_html_document.tap do |document|
+      document.css(NON_CONTENT_ELEMENTS).each(&:remove)
+      document.xpath("//text()[normalize-space(.) != '']").each { |node| node.content = " #{node.content} " }
+    end
+  end
+
+  def parse_html_document
+    Nokogiri::HTML(html)
+  rescue Nokogiri::SyntaxError => e
+    raise ParseError.new url, e.message
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -177,14 +177,24 @@ RSpec.describe Page do
       expect(page.dom).to be_a(Nokogiri::HTML::Document)
     end
 
-    it "ignores invisible elements" do
-      expect(page.dom.css("style, meta, div.d-none")).to be_empty
+    it "preserves hidden and technical elements in the raw DOM" do
+      expect(page.dom.at_css("style")).to be_present
+      expect(page.dom.at_css("meta")).to be_present
+      expect(page.dom.at_css("div.d-none")).to be_present
     end
 
     it "caches the parsed document" do
       first_dom = page.dom
       second_dom = page.dom
       expect(first_dom).to be(second_dom)
+    end
+
+    it "preserves root attributes on a visibility-hidden html element" do
+      page = build(:page, html: '<html lang="fr-FR" style="visibility:hidden"><body><p>Bonjour</p></body></html>')
+
+      expect(page.dom.root.name).to eq("html")
+      expect(page.dom.root["lang"]).to eq("fr-FR")
+      expect(page.dom.root["style"]).to include("visibility:hidden")
     end
 
     context "when HTML is invalid" do
@@ -291,21 +301,25 @@ RSpec.describe Page do
         end
       end
 
-      context "with invisible elements between headings" do
+      context "with hidden and technical elements between headings" do
         let(:body) do
           <<~HTML
             <h1>Start Section</h1>
             <p>Visible content</p>
+            <div hidden>Hidden attribute content</div>
             <div style="display: none;">Hidden content</div>
+            <div style="visibility: hidden;">Visibility hidden content</div>
             <script>console.log('script')</script>
             <h1>End Section</h1>
           HTML
         end
 
-        it "excludes invisible elements from result" do
+        it "includes hidden content but excludes technical nodes from result" do
           result = page.text(between_headings: [/Start/, /End/])
-          expect(result).to eq("Visible content")
-          expect(result).not_to include("Hidden content")
+          expect(result).to include("Visible content")
+          expect(result).to include("Hidden attribute content")
+          expect(result).to include("Hidden content")
+          expect(result).to include("Visibility hidden content")
           expect(result).not_to include("script")
         end
       end
@@ -663,6 +677,19 @@ RSpec.describe Page do
           links = page.links(between_headings: [/Start/, /End/], skip_files: false)
           expect(links.collect(&:text)).to eq(["PDF Document", "Regular Link"])
         end
+      end
+
+      it "returns links inside hidden containers between headings" do
+        page = build(:page, body: <<~HTML)
+          <h1>Start</h1>
+          <div hidden><a href="/hidden-attribute">Hidden Attribute Link</a></div>
+          <div style="display: none;"><a href="/hidden-style">Hidden Style Link</a></div>
+          <div style="visibility: hidden;"><a href="/hidden-visibility">Hidden Visibility Link</a></div>
+          <h1>End</h1>
+        HTML
+
+        links = page.links(between_headings: [/Start/, /End/])
+        expect(links.collect(&:text)).to eq(["Hidden Attribute Link", "Hidden Style Link", "Hidden Visibility Link"])
       end
 
       context "with string patterns" do

--- a/spec/services/find_accessibility_page_service_spec.rb
+++ b/spec/services/find_accessibility_page_service_spec.rb
@@ -94,6 +94,42 @@ RSpec.describe FindAccessibilityPageService do
       end
     end
 
+    context "when the homepage html root is visibility-hidden" do
+      let(:home_page_html) do
+        <<~HTML
+          <html style="visibility:hidden;opacity:0">
+            <body>
+              <footer>
+                <a href="https://accessibilite.example.org/declaration">Accessibilité : partiellement conforme</a>
+              </footer>
+            </body>
+          </html>
+        HTML
+      end
+
+      let(:expected_link_list) do
+        ["https://accessibilite.example.org/declaration"]
+      end
+
+      it "still prioritizes the accessibility link" do
+        allow(Crawler).to receive(:new).with(
+          root_url,
+          root_page_html: home_page_html,
+          queue: LinkList.new(expected_link_list)
+        ).and_return(crawler)
+
+        allow(crawler).to receive(:find_page).and_return(nil)
+
+        described_class.call(audit)
+
+        expect(Crawler).to have_received(:new).with(
+          root_url,
+          root_page_html: home_page_html,
+          queue: LinkList.new(expected_link_list)
+        )
+      end
+    end
+
     it "does nothing if no page is found" do
       allow(crawler).to receive(:find_page).and_return(nil)
 


### PR DESCRIPTION
# fix #456 
## Summary

`Page#dom` was removing elements matching `visibility:hidden`.

On some real sites, like https://www.agglo-larochelle.fr/ the root `<html>` element is rendered with `style="visibility:hidden"`, which caused the whole DOM to be stripped before audit checks ran.

This PR makes `Page#dom` a raw parser again and keeps extraction cleanup separate.

## Changes

- keep `Page#dom` as the raw parsed document
- move extraction cleanup into a separate internal content DOM
- keep hidden content in extraction
- still ignore non-content elements like `script`, `style`, `meta`, `link`, `noscript`, and `iframe`

## Result

This restores for those sites with hidden attributes the detection
<img width="848" height="1189" alt="Capture d’écran 2026-04-03 à 12 37 41" src="https://github.com/user-attachments/assets/b90d5210-dc57-4484-a706-87721583e6c6" />
