### PR TITLE
fix: create audit when resubmitting an existing site

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -3,7 +3,7 @@ class AuditsController < ApplicationController
 
   # POST /sites/1/audits
   def create
-    @audit = @site.audit!
+    @audit = @site.create_audit!
     if @audit.persisted?
       redirect_to [@site, @audit], notice: t(".notice")
     else

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -36,9 +36,8 @@ class SitesController < ApplicationController
   def create
     url = site_params[:url]
     @site = current_user.team.sites.find_by_url(url:) || current_user.team.sites.build
-    @site.assign_attributes(site_params)
     notice = t(@site.new_record? ? ".created" : ".new_audit")
-    if @site.save
+    if @site.save_and_create_audit_if_needed(site_params)
       redirect_to @site, notice:
     else
       render :new, status: :unprocessable_content

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -71,8 +71,34 @@ class Site < ApplicationRecord
     audits.find(&:current?) || audits.current.last || audits.first || audits.build(current: true)
   end
 
-  def audit!
+  def create_audit!
     audits.create!(url:, current: audits.current.none? || audits.none?)
+  end
+
+  def create_audit
+    audits.create(url:, current: audits.current.none? || audits.none?)
+  end
+
+  def save_and_create_audit_if_needed(attributes)
+    resubmitting_existing_site = persisted? && Link.normalize(attributes[:url]) == url
+    assign_attributes(attributes)
+
+    return save unless resubmitting_existing_site
+
+    with_transaction_returning_status do
+      next false unless save
+
+      audit = create_audit
+
+      if audit.persisted?
+        true
+      else
+        audit.errors.each do |error|
+          errors.add(error.attribute, error.message)
+        end
+        false
+      end
+    end
   end
 
   def actual_current_audit

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -41,7 +41,7 @@ class SiteUpload
 
     transaction do
       create!(new_sites.values) if new_sites.any?
-      existing_sites.values.each { |site| site.save && site.audit! }
+      existing_sites.values.each { |site| site.save && site.create_audit! }
     end
     true
   end

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -105,12 +105,16 @@ RSpec.describe "Sites" do
     end
 
     context "when URL already exists" do
-      it "doesn't create a duplicate site" do
+      it "creates a new audit for the existing site without creating a duplicate site" do
         existing_site = create(:site, url:, team:)
+        initial_site_count = Site.count
 
-        expect { post_site }.not_to change(Site, :count)
+        expect { post_site }.to change(Audit, :count).by(1)
+          .and change(Check, :count).by(Check.names.count)
 
+        expect(Site.count).to eq(initial_site_count)
         expect(response).to redirect_to(site_path(existing_site))
+        expect(flash[:notice]).to eq(I18n.t("sites.create.new_audit"))
       end
     end
 


### PR DESCRIPTION
Quand un utilisateur soumettait via `POST /sites` une URL déjà présente exactement à l’identique, l’application réutilisait bien le `Site` existant mais ne créait aucun nouvel `Audit`, alors que le message indiquait qu’un nouvel audit avait été programmé.

Cette PR:
- corrige le flux de création de site pour créer un nouvel audit lors de la resoumission d’un site existant avec la même URL
- garde le comportement existant pour les nouveaux sites
- évite toujours la création d’un site dupliqué
- clarifie la logique métier en la portant côté modèle `Site`
- ajoute un test de requête qui vérifie qu’on crée bien un audit et ses checks sans créer de second site
