### PR TITLE
chore: POC: remplacer mission_control-jobs par solid_queue_monitor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,7 @@ gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
 # Add a web interface to control jobs
-# DO NOT MERGE UNTIL PROPER RELEASE OF SOLID_QUEUE_MONITOR
-gem "solid_queue_monitor", github: 'vishaltps/solid_queue_monitor', branch: 'main'
+gem "solid_queue_monitor", "~> 1.3"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
 # Add a web interface to control jobs
-gem "mission_control-jobs", "~> 1.1"
+gem "solid_queue_monitor", "~> 1.2"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
 # Add a web interface to control jobs
-gem "solid_queue_monitor", "~> 1.2"
+# DO NOT MERGE UNTIL PROPER RELEASE OF SOLID_QUEUE_MONITOR
+gem "solid_queue_monitor", github: 'vishaltps/solid_queue_monitor', branch: 'main'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,15 @@ GIT
       rack (>= 2.2.3)
       rack-protection
 
+GIT
+  remote: https://github.com/vishaltps/solid_queue_monitor.git
+  revision: dee0e610a556737700ea8035646d77284192ce3f
+  branch: main
+  specs:
+    solid_queue_monitor (1.3.0)
+      rails (>= 7.0)
+      solid_queue (>= 0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -603,9 +612,6 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    solid_queue_monitor (1.2.2)
-      rails (>= 7.0)
-      solid_queue (>= 0.1.0)
     stackprof (0.2.28)
     statesman (13.1.0)
     stimulus-rails (1.3.4)
@@ -723,7 +729,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
-  solid_queue_monitor (~> 1.2)
+  solid_queue_monitor!
   stackprof
   statesman
   stimulus-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,15 +9,6 @@ GIT
       rack (>= 2.2.3)
       rack-protection
 
-GIT
-  remote: https://github.com/vishaltps/solid_queue_monitor.git
-  revision: dee0e610a556737700ea8035646d77284192ce3f
-  branch: main
-  specs:
-    solid_queue_monitor (1.3.0)
-      rails (>= 7.0)
-      solid_queue (>= 0.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -612,6 +603,9 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    solid_queue_monitor (1.3.0)
+      rails (>= 7.0)
+      solid_queue (>= 0.1.0)
     stackprof (0.2.28)
     statesman (13.1.0)
     stimulus-rails (1.3.4)
@@ -729,7 +723,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
-  solid_queue_monitor!
+  solid_queue_monitor (~> 1.3)
   stackprof
   statesman
   stimulus-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,16 +348,6 @@ GEM
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
-    mission_control-jobs (1.1.0)
-      actioncable (>= 7.1)
-      actionpack (>= 7.1)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      importmap-rails (>= 1.2.1)
-      irb (~> 1.13)
-      railties (>= 7.1)
-      stimulus-rails
-      turbo-rails
     msgpack (1.8.0)
     multi_test (1.1.0)
     nenv (0.3.0)
@@ -613,6 +603,9 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    solid_queue_monitor (1.2.2)
+      rails (>= 7.0)
+      solid_queue (>= 0.1.0)
     stackprof (0.2.28)
     statesman (13.1.0)
     stimulus-rails (1.3.4)
@@ -704,7 +697,6 @@ DEPENDENCIES
   importmap-rails
   markdown_views
   memory_profiler
-  mission_control-jobs (~> 1.1)
   omniauth!
   omniauth-proconnect
   omniauth-rails_csrf_protection
@@ -731,6 +723,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  solid_queue_monitor (~> 1.2)
   stackprof
   statesman
   stimulus-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,8 +86,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
-  # Disable HTTP Basic Auth for mission control jobs
-  config.mission_control.jobs.http_basic_auth_enabled = false
-
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/config/initializers/solid_queue_monitor.rb
+++ b/config/initializers/solid_queue_monitor.rb
@@ -1,0 +1,14 @@
+SolidQueueMonitor.setup do |config|
+  config.authentication_enabled = Rails.env.production?
+  config.username = Rails.application.credentials.dig(:solid_queue_monitor, :username) # TODO: add it to credentials for production
+  config.password = Rails.application.credentials.dig(:solid_queue_monitor, :password) # TODO: add it to credentials for production
+  config.jobs_per_page = 25
+  config.auto_refresh_enabled = true
+  config.auto_refresh_interval = 30
+end
+
+Rails.application.config.to_prepare do
+  # The gem renders inline <style>/<script> tags and also mutates inline styles from JavaScript,
+  # which conflicts with the application's strict CSP. See /config/initializers/content_security_policy.rb
+  SolidQueueMonitor::ApplicationController.content_security_policy false
+end

--- a/config/initializers/solid_queue_monitor.rb
+++ b/config/initializers/solid_queue_monitor.rb
@@ -6,9 +6,3 @@ SolidQueueMonitor.setup do |config|
   config.auto_refresh_enabled = true
   config.auto_refresh_interval = 30
 end
-
-Rails.application.config.to_prepare do
-  # The gem renders inline <style>/<script> tags and also mutates inline styles from JavaScript,
-  # which conflicts with the application's strict CSP. See /config/initializers/content_security_policy.rb
-  SolidQueueMonitor::ApplicationController.content_security_policy false
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
   end
 
   # Operational URLs
-  mount MissionControl::Jobs::Engine, at: "/jobs"
+  mount SolidQueueMonitor::Engine, at: "/jobs"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
POC pour tester solid_queue_monitor en remplacement de mission_control-jobs.

La gem est bien intégrée et montée sur /jobs, avec authentification en production via les credentials Rails (qu'il faudra encore ajouter si jamais on part dans cette direction). 

<img width="1512" height="683" alt="Capture d’écran 2026-04-13 à 12 17 07" src="https://github.com/user-attachments/assets/0c7d449f-b16c-4ddb-8e46-0b1a24b25c2b" />
<img width="1499" height="1197" alt="Capture d’écran 2026-04-13 à 12 16 53" src="https://github.com/user-attachments/assets/0f81b032-4cae-44a2-9b47-10a6c555ba76" />
<img width="1513" height="1191" alt="Capture d’écran 2026-04-13 à 12 16 40" src="https://github.com/user-attachments/assets/61560957-d0aa-41d3-b358-fdaef588904c" />

