### PR TITLE
feat: améliorer le découpage des sections par niveau de heading

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -155,10 +155,26 @@ class Page
 
     case direction
     when :next
-      headings[index + 1]
+      next_section_boundary(node, headings)
     when :previous
       index > 0 ? headings[index - 1] : nil
     end
+  end
+
+  def next_section_boundary(node, headings)
+    index = headings.index(node)
+    return nil unless index
+
+    current_level = heading_level(node)
+    following_headings = headings[(index + 1)..]
+
+    following_headings.find do |candidate|
+      heading_level(candidate) <= current_level
+    end
+  end
+
+  def heading_level(node)
+    node.name.delete_prefix("h").to_i
   end
 
   def find_heading_nodes(start_matcher, end_matcher)
@@ -184,17 +200,21 @@ class Page
     start_matcher, end_matcher = between_headings
     start_node, end_node = find_heading_nodes(start_matcher, end_matcher)
 
-    if start_node && end_node
+    if start_node
       dom_between(start_node, end_node)
     else
       dom.fragment
     end
   end
 
-  def dom_between(start_node, end_node)
-    # Find all nodes between start_node and end_node
-    # (following-siblings only works when nodes are at the same level)
-    nodes_between = start_node.xpath("following::*") & end_node.xpath("preceding::*")
+  def dom_between(start_node, end_node = nil)
+    nodes_between = if end_node
+      # Find all nodes between start_node and end_node
+      # (following-siblings only works when nodes are at the same level)
+      start_node.xpath("following::*") & end_node.xpath("preceding::*")
+    else
+      start_node.xpath("following::*")
+    end
 
     # Remove nodes whose parent is already included (UL>LI,P>EM etc)
     deduped_nodes = nodes_between.reject do |node|

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -251,6 +251,20 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
         expect(check.find_compliance_rate).to eq(expected_rate)
       end
     end
+
+    it "extracts the updated rate when test results start with a nested heading" do
+      body = <<~HTML
+        <h2>Résultats des tests</h2>
+        <h3>Résultats des tests</h3>
+        <p>L’audit de conformité réalisé par la société <strong>IPEDIS</strong> révèle que :</p>
+        <p>Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% sur l’ensemble critères du référentiel générale d’amélioration de l’accessibilité (RGAA).</p>
+        <h2>Contenus non accessibles</h2>
+      HTML
+      allow(check).to receive(:page).and_return(build(:page, body:))
+
+      expect(check.find_compliance_rate).to eq(71.21)
+      expect(check.find_auditor).to eq("IPEDIS")
+    end
   end
 
   describe "#find_standard" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -408,6 +408,20 @@ RSpec.describe Page do
           expect(result).to eq("Content in second section")
         end
 
+        it "includes nested sub-sections until the next heading of the same or higher level" do
+          body = <<~HTML
+            <h2>Results</h2>
+            <h3>Results</h3>
+            <p>Audit details</p>
+            <p>71,21%</p>
+            <h2>Other section</h2>
+          HTML
+          page = described_class.new(url: "https://example.com", html: body)
+
+          result = page.text(between_headings: [/Results/, :next])
+          expect(result).to eq("Results Audit details 71,21%")
+        end
+
         context "when matched heading is the last heading" do
           it "returns empty string" do
             result = page.text(between_headings: [/Third Heading/, :next])
@@ -420,6 +434,19 @@ RSpec.describe Page do
             result = page.text(between_headings: [/Nonexistent/, :next])
             expect(result).to eq("")
           end
+        end
+
+        it "returns the section until the end of the document when no heading of the same or higher level follows" do
+          body = <<~HTML
+            <h2>Section</h2>
+            <p>Intro</p>
+            <h3>Details</h3>
+            <p>Tail content</p>
+          HTML
+          page = described_class.new(url: "https://example.com", html: body)
+
+          result = page.text(between_headings: [/Section/, :next])
+          expect(result).to eq("Intro Details Tail content")
         end
       end
 
@@ -456,6 +483,36 @@ RSpec.describe Page do
             result = page.text(between_headings: [:previous, /Nonexistent/])
             expect(result).to eq("")
           end
+        end
+
+        it "keeps previous matching scoped to the immediately preceding heading" do
+          body = <<~HTML
+            <h1>Overview</h1>
+            <p>Overview content</p>
+            <h2>Details</h2>
+            <p>Details content</p>
+            <h3>Nested</h3>
+            <p>Nested content</p>
+          HTML
+          page = described_class.new(url: "https://example.com", html: body)
+
+          result = page.text(between_headings: [:previous, /Details/])
+          expect(result).to eq("Overview content")
+        end
+      end
+
+      context "when the explicit ending heading is not found" do
+        let(:body) do
+          <<~HTML
+            <h2>Section A</h2>
+            <p>Alpha content</p>
+            <h2>Section C</h2>
+          HTML
+        end
+
+        it "returns empty string" do
+          result = page.text(between_headings: ["Section A", "Section B"])
+          expect(result).to eq("")
         end
       end
 


### PR DESCRIPTION
## Contexte

Sur la page d’accessibilité de Carrefour, le taux de conformité n’était pas détecté.

Le problème vient de la structure HTML de la section `Résultats des tests` :
un `h2` est immédiatement suivi d’un `h3` portant le même intitulé.
Aujourd’hui, notre logique de découpage avec `:next` s’arrête au heading suivant sans tenir compte de son niveau, ce qui fait que la section analysée peut être vide ou tronquée.

## Ce que fait cette PR

- améliore le découpage des sections basé sur les headings
- fait en sorte que `:next` s’arrête au prochain heading de même niveau ou supérieur
- ajoute des tests autour de ce comportement
- ajoute un cas de régression reproduisant la structure rencontrée sur Carrefour

## Effet attendu

La section `Résultats des tests` de Carrefour est correctement analysée, ce qui permet de retrouver :
- le taux de conformité `71.21`
- l’auditeur `IPEDIS`

## Point à discuter

Cette PR introduit un changement de comportement plus général dans la manière de découper les sections HTML.
J'ai laissé pour l'instant les regression pour bien qu'on comprenne l'impact de cette PR.

Question ouverte :
est-ce qu’on veut assumer cette nouvelle sémantique de `:next` globalement, car elle est plus proche de la structure logique des headings HTML, ou préférer une correction plus ciblée sur ce cas précis ?

Discussion dans #484  
