### PR TITLE
feat: ajout du BOM UTF-8 aux exports CSV

### DIFF
--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -1,5 +1,6 @@
 class SiteCsvExport
   COL_SEP = ";"
+  UTF8_BOM = "\uFEFF"
 
   HEADERS = [
     I18n.t("audit.site_url_address"),
@@ -32,6 +33,7 @@ class SiteCsvExport
   end
 
   def self.stream_csv_to(output_stream, sites)
+    output_stream.write(UTF8_BOM)
     output_stream.write CSV.generate_line(HEADERS, col_sep: COL_SEP)
 
     sites.in_batches(of: 200) do |batch|

--- a/spec/export/site_csv_export_spec.rb
+++ b/spec/export/site_csv_export_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe SiteCsvExport do
   let(:team) { create(:team) }
   let(:tags) { ["Gouvernment", "Santé publique"].map { |name| create(:tag, name:, team:) } }
   let(:site) { create(:site, :completed, url: "https://example.com", team:, tags:) }
+  let(:csv_without_bom) { csv_output.delete_prefix(described_class::UTF8_BOM) }
 
   describe ".filename" do
     it "generates filename with current date" do
@@ -14,12 +15,16 @@ RSpec.describe SiteCsvExport do
   end
 
   describe ".stream_csv_to" do
-    subject(:parsed_csv) { CSV.parse(csv_output, col_sep: ";", headers: true) }
+    subject(:parsed_csv) { CSV.parse(csv_without_bom, col_sep: ";", headers: true) }
 
     let(:csv_output) do
       output = StringIO.new
       described_class.stream_csv_to(output, Site.where(id: site.id))
       output.string
+    end
+
+    it "prefixes the CSV with a UTF-8 BOM" do
+      expect(csv_output).to start_with(described_class::UTF8_BOM)
     end
 
     context "with completed checks" do

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Sites" do
     let!(:other_site) { create(:site, :completed, team:, tag_ids: [tag.id]) }
 
     let(:request_params) { {} }
+    let(:csv_without_bom) { response.body.delete_prefix(SiteCsvExport::UTF8_BOM) }
 
     it "returns CSV content" do
       get_csv
@@ -42,12 +43,13 @@ RSpec.describe "Sites" do
       expect(response.content_type).to include("text/csv")
       expect(response.headers["Content-Disposition"]).to include("attachment")
       expect(response.headers["Content-Disposition"]).to include("sites_")
+      expect(response.body).to start_with(SiteCsvExport::UTF8_BOM)
     end
 
     it "includes sites data in CSV" do
       get_csv
 
-      csv = CSV.parse(response.body, col_sep: ";", headers: true)
+      csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
       expect(csv.count).to eq(2)
       expect(csv[0]["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
       expect(csv[1]["Adresse du site"]).to eq(site.url_without_scheme_and_www)
@@ -59,7 +61,7 @@ RSpec.describe "Sites" do
       it "returns only selected sites" do
         get_csv
 
-        csv = CSV.parse(response.body, col_sep: ";", headers: true)
+        csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
         expect(csv.count).to eq(1)
         expect(csv.first["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
       end
@@ -71,7 +73,7 @@ RSpec.describe "Sites" do
       it "returns only tagged sites" do
         get_csv
 
-        csv = CSV.parse(response.body, col_sep: ";", headers: true)
+        csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
         expect(csv.count).to eq(1)
         expect(csv.first["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
       end


### PR DESCRIPTION
Ajoute un BOM UTF-8 au début des exports CSV pour que les accents soient correctement affichés à l’ouverture dans les tableurs. Met à jour les specs d’export et de requête pour couvrir ce comportement.
Avant : 
<img width="334" height="91" alt="avant" src="https://github.com/user-attachments/assets/b5eb02b7-4643-4d22-933f-9e7f1a48f1a7" />
Apres : 
<img width="294" height="96" alt="apres" src="https://github.com/user-attachments/assets/30263199-13c2-40af-8768-fd5a53c9d794" />
