### PR TITLE
fix: invalid years translation

### DIFF
--- a/app/views/pages/checks/analyze_plan.html.md
+++ b/app/views/pages/checks/analyze_plan.html.md
@@ -26,7 +26,7 @@ Un simple texte sans lien dans la déclaration est relevé en tant qu'avertissem
         <td>Réussi - Lien trouvé et valide</td>
       </tr>
       <tr>
-        <td><p class="fr-badge fr-badge--warning"><%= t("checks.analyze_plan.invalid_year") %></p></td>
+        <td><p class="fr-badge fr-badge--warning"><%= t("checks.analyze_plan.invalid_years") %></p></td>
         <td>Avertissement - Lien trouvé et valide, mais les années précisées sont invalides (anciennes/incohérentes) </td>
       </tr>
       <tr>


### PR DESCRIPTION
fix #464 

Mauvaise traduction corrigée
<img width="841" height="422" alt="Capture d’écran 2026-04-16 à 15 12 11" src="https://github.com/user-attachments/assets/9706c978-91da-4995-8537-aee7205b195f" />
