### PR TITLE
chore: supprimer les traductions inutilisés

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :development do
   gem "rack-mini-profiler"
   gem "memory_profiler"
   gem "stackprof"
+  gem "i18n-tasks", "~> 1.1.2"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,8 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
+    highline (3.1.2)
+      reline
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     http (6.0.2)
@@ -292,6 +294,18 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.1.2)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 3.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      prism
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
@@ -621,6 +635,8 @@ GEM
     sys-uname (1.5.0)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     thread_safe (0.3.6)
     timeout (0.6.1)
@@ -701,6 +717,7 @@ DEPENDENCIES
   guard-cucumber
   guard-rspec
   http
+  i18n-tasks (~> 1.1.2)
   importmap-rails
   markdown_views
   memory_profiler

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -43,7 +43,11 @@ class SitesController < ApplicationController
     url = site_params[:url]
     @site = current_user.team.sites.find_by_url(url:) || current_user.team.sites.build
     @site.assign_attributes(site_params)
-    notice = t(@site.new_record? ? ".created" : ".new_audit")
+    notice = if @site.new_record?
+      t(".created")
+    else
+      t(".new_audit")
+    end
     if @site.save
       redirect_to @site, notice:
     else

--- a/app/models/checks/accessibility_mention.rb
+++ b/app/models/checks/accessibility_mention.rb
@@ -17,7 +17,10 @@ module Checks
     delegate :text, to: :root_page, prefix: true
 
     def mention_text
-      completed? ? t("#{mention || 'none'}", scope: "checks.accessibility_mention.mentions") : ""
+      return "" unless completed?
+
+      key = mention || "none"
+      t("checks.accessibility_mention.mentions.#{key}")
     end
 
     def custom_badge_text

--- a/app/models/checks/find_accessibility_page.rb
+++ b/app/models/checks/find_accessibility_page.rb
@@ -13,7 +13,11 @@ module Checks
     end
 
     def custom_badge_text
-      t(found? ? "link_to_page" : "not_found", scope: "checks.find_accessibility_page")
+      if found?
+        t("checks.find_accessibility_page.link_to_page")
+      else
+        t("checks.find_accessibility_page.not_found")
+      end
     end
 
     def custom_badge_status

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -12,7 +12,11 @@ module Checks
     end
 
     def custom_badge_text
-      t(redirected? ? "redirected" : "reachable", scope: "checks.reachable")
+      if redirected?
+        t("checks.reachable.redirected")
+      else
+        t("checks.reachable.reachable")
+      end
     end
 
     def custom_badge_status

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -46,7 +46,11 @@
     <% else %>
       <tr>
         <td colspan="<%= 5 + Check.classes.size %>">
-          <%= t(params.dig(:filter, :q).present? ? '.no_search_results' : '.no_results') %>
+          <% if params.dig(:filter, :q).present? %>
+            <%= t(".no_search_results") %>
+          <% else %>
+            <%= t(".no_results") %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,153 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: fr
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `Dir.glob` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, isolating_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `Find.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ## - DefaultI18nSubjectMatcher
+  ##     Matches ActionMailer's default_i18n_subject method
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  # ast_matchers:
+  #   - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+  #   - 'I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher'
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+  ast_matchers:
+    - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+ignore_unused:
+  - 'activemodel.attributes.site_upload.file'
+  - 'activemodel.errors.models.site_upload.attributes.file.*'
+  - 'activerecord.attributes.{site,tag}.*'
+  - 'activerecord.errors.attributes.url.invalid'
+  - 'activerecord.models.site*'
+  - 'activerecord.models.team*'
+  - 'date.formats.compact'
+  - 'pagy.*'
+  - 'time.formats.{complete,file}'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,11 +32,6 @@ fr:
         other: Équipes
   audit:
     completed_at: Executé le
-    count:
-      one: Une vérification
-      other: "%{count} vérifications"
-      zero: Aucune vérification
-    new: "Nouvelle vérification"
     redirect_url: URL de redirection
     site_url_address: Adresse du site
     state: État
@@ -52,13 +47,7 @@ fr:
     create:
       notice: Vérification créée
   check:
-    attempts: Tentatives
     completed_at: Vérification effectuée le
-    count:
-      one: Un contrôle
-      other: "%{count} contrôles"
-      zero: Aucun contrôle
-    state: État
     status:
       aborted: Annulé
       blocked: Inapplicable
@@ -68,7 +57,6 @@ fr:
       pending: Planifié
       ready: Prêt
       running: En cours
-    type: Type de contrôle
   checks:
     accessibility_mention:
       mentions:
@@ -87,9 +75,7 @@ fr:
         one: "Un seul problème relevé sur %{total} titres attendus (%{error})."
         other: "Sur la page controlée, %{count} problèmes ont été relevés sur un total de %{total} titres attendus."
         zero: "Tous les titres attendus ont été trouvé, dans le bon ordre et avec la bonne hiérarchie. C'est bien !"
-      not_found: Non trouvé
       retained: "Titre retenu :"
-      score: Taux de correspondance
       statuses:
         incorrect_level: niveau de titre incorrect
         incorrect_order: ordre incorrect
@@ -104,7 +90,6 @@ fr:
       contact_email: Adresse email de contact
       contact_form: Formulaire de contact
       compliance_rate: Taux de conformité
-      found_all: Déclaration complète
       mentions_article: Mentionne l'article de loi
       missing_data: Déclaration incomplète
       standard: Référentiel
@@ -148,11 +133,9 @@ fr:
       not_found: Non trouvée
       table_header: Déclaration
       type: Présence d'une déclaration d'accessibilité
-      view_page: "Voir la déclaration"
     language_indication:
       empty: Non trouvée
       table_header: Langue
-      totalement: Totalement conforme
       type: Indication de la langue
     reachable:
       reachable: Joignable à l'adresse indiquée
@@ -160,7 +143,6 @@ fr:
       redirected: Redirection
       type: Site joignable
     run_axe_on_homepage:
-      checks_total: Contrôles effectués
       elements_count:
         one: un élément concerné
         other: "%{count} éléments concernés"
@@ -170,16 +152,9 @@ fr:
         minor: impact mineur
         moderate: impact modéré
         serious: impact important
-      inapplicable: Contrôles inapplicables
-      incomplete: Contrôles incomplets
-      issues_total: Erreurs relevées
-      passes: Contrôles réussis
-      redirected: Contrôles
       success_rate: Taux de réussite
       table_header: "🤖 : Accueil"
       type: "Contrôles automatiques : page d'accueil"
-      unknown: Inconnu
-      violations: Contrôles échoués
   date:
     formats:
       compact: "%Y/%m/%d"
@@ -191,21 +166,11 @@ fr:
   global:
     service_description: "Contrôle l'accessibilité et la conformité des sites internet"
     service_name: "Accès cible (version beta)"
-    sponsor: "Gouvernement"
     sponsor_html: "Gouvernement"
   pages:
     accessibilite:
       title: Déclaration d’accessibilité
     accueil:
-      stats:
-        sites_count:
-          one: Un site
-          other: "%{count} sites"
-          zero: Aucun site
-        teams_count:
-          one: Une équipe
-          other: "%{count} équipes"
-          zero: Aucune équipe
       title: Présentation
     contact:
       title: Contact
@@ -275,10 +240,6 @@ fr:
     help: Aide
     import: Importer
     importing: Import en cours…
-    lines:
-      one: 1 ligne
-      other: "%{count} lignes"
-      zero: 0 lignes
     login: Se connecter
     logout: Se déconnecter
     new_window: " (nouvelle fenêtre)"
@@ -305,10 +266,6 @@ fr:
   sites:
     add: Ajouter un site
     all: Tous les sites
-    count:
-      one: Un site
-      other: "%{count} sites"
-      zero: Aucun site
     create:
       created: Site ajouté
       new_audit: Site existant, nouvel audit programmé
@@ -346,7 +303,6 @@ fr:
     show:
       audit_history: Historique des vérifications (%{total})
       audits: Toutes les vérifications
-      audits_count: Vérifications
       delete: Supprimer ce site
       edit: Modifier ce site
       new_audit: Nouvelle vérification
@@ -367,32 +323,12 @@ fr:
         one: Un site ajouté
         other: "%{count} sites ajoutés"
         zero: Aucun site ajouté
-  tag:
-    add: Créer une nouvelle étiquette
-    all: Toutes les étiquettes
-    count:
-      one: Une étiquette
-      other: "%{count} étiquettes"
-      zero: Aucune étiquette
-    delete: Supprimer cette étiquette
-    edit: Modifier cette étiquette
-    filter: Filtrer par étiquette
-    name: Libellé
-    new: Nouvelle étiquette
-    see_sites: Sites avec l'étiquette %{tag} (%{count})
-    sites: Sites
-    tag: Étiquette %{name}
   tags:
     all: Toutes les étiquettes
     destroy:
       notice: Étiquette supprimée
     edit:
-      name: Libellé
       title: Modifier l'étiquette
-    form:
-      add: Créer une nouvelle étiquette
-      all: Toutes les étiquettes
-      new: Nouvelle étiquette
     index:
       caption: Toutes les étiquettes
       empty: Aucune étiquette
@@ -407,15 +343,8 @@ fr:
       see_sites: "Sites avec l'étiquette %{tag} (%{count})"
     update:
       notice: Étiquette modifiée
-  team:
-    all: Équipes
-    count:
-      one: Une équipe
-      other: "%{count} équipes"
-      zero: Aucune équipe
   time:
     formats:
-      compact: "%Y/%m/%d"
       complete: "%d/%m/%Y à %H:%M"
       file: "%Y%m%d-%Hh%M"
   users:


### PR DESCRIPTION
Nous avons beaucoup de traductions i18n qui ne sont plus utilisés.

J'ai ajouté la gem i18n-tasks pour tracker ces traductions inutilisées

J'ai vérifié une par une les potentielles traductions non utilisées et j'en ai supprimé 71 🍾 

J'ai modifié les translations générées de manière conditionnelles qui déclenchent des faux positifs sur la gem i18n-tasks