### PR TITLE
feat: utiliser les headings de déclaration pour extraire les sections

### DIFF
--- a/app/models/checks/accessibility_page_heading.rb
+++ b/app/models/checks/accessibility_page_heading.rb
@@ -1,5 +1,7 @@
 module Checks
   class AccessibilityPageHeading < Check
+    include AccessibilityDeclarationHeadings
+
     PRIORITY = 22
     REQUIREMENTS = Check::REQUIREMENTS + [:find_accessibility_page]
     COMPARISON_OPTIONS = { fuzzy: 0.65, ignore_case: true }.freeze
@@ -15,7 +17,7 @@ module Checks
     end
 
     def total
-      AccessibilityDeclarationHeadings.expected_heading_titles.count
+      expected_declaration_heading_titles.count
     end
 
     def failures
@@ -65,7 +67,7 @@ module Checks
     end
 
     def indexed_expected_headings
-      @indexed_expected_headings ||= AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.each_with_index.map do |(level, heading), index|
+      @indexed_expected_headings ||= expected_declaration_headings.each_with_index.map do |(level, heading), index|
         [index, heading, level]
       end
     end
@@ -75,7 +77,7 @@ module Checks
     end
 
     def compare_headings
-      return AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.map { |level, heading| [heading, level, :missing, nil] } unless page_headings
+      return expected_declaration_headings.map { |level, heading| [heading, level, :missing, nil] } unless page_headings
 
       # Two-pass approach: first match all headings, then determine status
       expected_to_actual = {}

--- a/app/models/checks/accessibility_page_heading.rb
+++ b/app/models/checks/accessibility_page_heading.rb
@@ -2,30 +2,7 @@ module Checks
   class AccessibilityPageHeading < Check
     PRIORITY = 22
     REQUIREMENTS = Check::REQUIREMENTS + [:find_accessibility_page]
-    EXPECTED_HEADINGS = [
-      [2, "État de conformité"],
-      [3, "Résultats des tests"],
-      [2, "Contenus non accessibles"],
-      [3, "Non-conformités"],
-      [3, "Dérogations pour charge disproportionnée"],
-      [3, "Contenus non soumis à l'obligation d'accessibilité"],
-      [2, "Établissement de cette déclaration d'accessibilité"],
-      [3, "Technologies utilisées pour la réalisation du site"],
-      [3, "Environnement de test"],
-      [3, "Outils pour évaluer l'accessibilité"],
-      [3, "Pages du site ayant fait l'objet de la vérification de conformité"],
-      [2, "Retour d'information et contact"],
-      [2, "Voies de recours"],
-    ].freeze
     COMPARISON_OPTIONS = { fuzzy: 0.65, ignore_case: true }.freeze
-
-    delegate :expected_headings, to: :class
-
-    class << self
-      def expected_headings
-        EXPECTED_HEADINGS.collect(&:last)
-      end
-    end
 
     store_accessor :data, :page_headings, :comparison
 
@@ -38,7 +15,7 @@ module Checks
     end
 
     def total
-      expected_headings.count
+      AccessibilityDeclarationHeadings.expected_heading_titles.count
     end
 
     def failures
@@ -88,7 +65,9 @@ module Checks
     end
 
     def indexed_expected_headings
-      @indexed_expected_headings ||= EXPECTED_HEADINGS.each_with_index.map { |(level, heading), index| [index, heading, level] }
+      @indexed_expected_headings ||= AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.each_with_index.map do |(level, heading), index|
+        [index, heading, level]
+      end
     end
 
     def indexed_page_headings
@@ -96,7 +75,7 @@ module Checks
     end
 
     def compare_headings
-      return EXPECTED_HEADINGS.map { |level, heading| [heading, level, :missing, nil] } unless page_headings
+      return AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.map { |level, heading| [heading, level, :missing, nil] } unless page_headings
 
       # Two-pass approach: first match all headings, then determine status
       expected_to_actual = {}

--- a/app/models/checks/analyze_accessibility_page.rb
+++ b/app/models/checks/analyze_accessibility_page.rb
@@ -1,5 +1,7 @@
 module Checks
   class AnalyzeAccessibilityPage < Check
+    include AccessibilityDeclarationHeadings
+
     PRIORITY = 21
     REQUIREMENTS = Check::REQUIREMENTS + [:find_accessibility_page]
 
@@ -170,7 +172,7 @@ module Checks
     end
 
     def declaration_heading?(text)
-      AccessibilityDeclarationHeadings.expected_heading_titles.any? { |heading| heading_match?(heading, text) }
+      expected_declaration_heading_titles.any? { |heading| heading_match?(heading, text) }
     end
 
     def heading_match?(matcher, text)

--- a/app/models/checks/analyze_accessibility_page.rb
+++ b/app/models/checks/analyze_accessibility_page.rb
@@ -25,6 +25,7 @@ module Checks
     MAILTO_PREFIX = "mailto:".freeze
     LAW_DATE = Date.new(2005, 2, 11)
     HEADERS_SCOPE = ["Établissement de cette déclaration d’accessibilité", "État de conformité", "Déclaration d’accessibilité", "Résultats des tests"]
+    HEADING_COMPARISON_OPTIONS = { ignore_case: true, fuzzy: 0.65 }.freeze
 
     store_accessor :data, :audit_date, :audit_update_date, :compliance_rate, :standard, :auditor, :mentions_article, :contact_email, :contact_form
 
@@ -68,7 +69,7 @@ module Checks
       extracted_text = []
 
       HEADERS_SCOPE.each do |header_scope|
-        extracted_text << page.text(between_headings: [header_scope, :next])
+        extracted_text << declaration_section_text(header_scope)
       end
 
       extracted_text << page.text(between_headings: [:previous, "État de conformité"])
@@ -82,7 +83,7 @@ module Checks
     end
 
     def find_compliance_rate
-      test_results_section = page.text(between_headings: ["Résultats des tests", :next])
+      test_results_section = declaration_section_text("Résultats des tests")
       matches = test_results_section.scan(COMPLIANCE_PATTERN)
 
       return if matches.empty?
@@ -99,7 +100,7 @@ module Checks
     end
 
     def find_auditor
-      test_results_section = page.text(between_headings: ["Résultats des tests", :next])
+      test_results_section = declaration_section_text("Résultats des tests")
 
       match = test_results_section.match(AUDITOR_PATTERN)&.[](1)&.strip
       match if match && match.split.size <= 4 # Names longer than 4 words are probably false positives
@@ -123,7 +124,7 @@ module Checks
 
       return email_in_text if email_in_text.present?
 
-      page.mailto_addresses(between_headings: ["Retour d'information et contact", :next]).first
+      declaration_section_mailto_addresses("Retour d'information et contact").first
     end
 
     def find_contact_form
@@ -135,11 +136,45 @@ module Checks
     private
 
     def contact_links
-      page.links(between_headings: ["Retour d'information et contact", :next])
+      declaration_section_links("Retour d'information et contact")
     end
 
     def contact_section_text
-      page.text(between_headings: ["Retour d'information et contact", :next])
+      declaration_section_text("Retour d'information et contact")
+    end
+
+    def declaration_section_text(start_heading)
+      page.text(between_headings: declaration_section_boundaries(start_heading))
+    end
+
+    def declaration_section_links(start_heading)
+      page.links(between_headings: declaration_section_boundaries(start_heading))
+    end
+
+    def declaration_section_mailto_addresses(start_heading)
+      page.mailto_addresses(between_headings: declaration_section_boundaries(start_heading))
+    end
+
+    def declaration_section_boundaries(start_heading)
+      [start_heading, next_declaration_heading(start_heading) || :next]
+    end
+
+    def next_declaration_heading(start_heading)
+      headings = page.headings
+      start_index = headings.find_index { |heading| heading_match?(start_heading, heading) }
+      return nil unless start_index
+
+      headings[(start_index + 1)..]&.find do |heading|
+        declaration_heading?(heading) && !heading_match?(start_heading, heading)
+      end
+    end
+
+    def declaration_heading?(text)
+      AccessibilityDeclarationHeadings.expected_heading_titles.any? { |heading| heading_match?(heading, text) }
+    end
+
+    def heading_match?(matcher, text)
+      StringComparison.match?(matcher, text, **HEADING_COMPARISON_OPTIONS)
     end
 
     def page

--- a/app/models/concerns/accessibility_declaration_headings.rb
+++ b/app/models/concerns/accessibility_declaration_headings.rb
@@ -1,0 +1,21 @@
+module AccessibilityDeclarationHeadings
+  EXPECTED_HEADINGS = [
+    [2, "État de conformité"],
+    [3, "Résultats des tests"],
+    [2, "Contenus non accessibles"],
+    [3, "Non-conformités"],
+    [3, "Dérogations pour charge disproportionnée"],
+    [3, "Contenus non soumis à l'obligation d'accessibilité"],
+    [2, "Établissement de cette déclaration d'accessibilité"],
+    [3, "Technologies utilisées pour la réalisation du site"],
+    [3, "Environnement de test"],
+    [3, "Outils pour évaluer l'accessibilité"],
+    [3, "Pages du site ayant fait l'objet de la vérification de conformité"],
+    [2, "Retour d'information et contact"],
+    [2, "Voies de recours"],
+  ].freeze
+
+  def self.expected_heading_titles
+    EXPECTED_HEADINGS.map { |_, heading_title| heading_title }
+  end
+end

--- a/app/models/concerns/accessibility_declaration_headings.rb
+++ b/app/models/concerns/accessibility_declaration_headings.rb
@@ -1,4 +1,6 @@
 module AccessibilityDeclarationHeadings
+  extend ActiveSupport::Concern
+
   EXPECTED_HEADINGS = [
     [2, "État de conformité"],
     [3, "Résultats des tests"],
@@ -15,7 +17,11 @@ module AccessibilityDeclarationHeadings
     [2, "Voies de recours"],
   ].freeze
 
-  def self.expected_heading_titles
-    EXPECTED_HEADINGS.map { |_, heading_title| heading_title }
+  def expected_declaration_headings
+    EXPECTED_HEADINGS
+  end
+
+  def expected_declaration_heading_titles
+    expected_declaration_headings.map { |_, heading_title| heading_title }
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -186,16 +186,26 @@ class Page
 
     if start_node && (end_node || end_matcher == :next)
       dom_between(start_node, end_node)
+    elsif end_node && start_matcher == :previous
+      dom_between(start_node, end_node)
     else
       dom.fragment
     end
   end
 
-  def dom_between(start_node, end_node = nil)
-    # Find all nodes after start_node, optionally bounded by end_node.
+  def dom_between(start_node = nil, end_node = nil)
+    # Find all nodes after start_node, before end_node, or between both.
     # (following-siblings only works when nodes are at the same level)
-    nodes_between = start_node.xpath("following::*")
-    nodes_between &= end_node.xpath("preceding::*") if end_node
+    nodes_between =
+      if start_node && end_node
+        start_node.xpath("following::*") & end_node.xpath("preceding::*")
+      elsif start_node
+        start_node.xpath("following::*")
+      elsif end_node
+        end_node.xpath("preceding::*")
+      else
+        []
+      end
 
     # Remove nodes whose parent is already included (UL>LI,P>EM etc)
     deduped_nodes = nodes_between.reject do |node|

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -184,17 +184,18 @@ class Page
     start_matcher, end_matcher = between_headings
     start_node, end_node = find_heading_nodes(start_matcher, end_matcher)
 
-    if start_node && end_node
+    if start_node && (end_node || end_matcher == :next)
       dom_between(start_node, end_node)
     else
       dom.fragment
     end
   end
 
-  def dom_between(start_node, end_node)
-    # Find all nodes between start_node and end_node
+  def dom_between(start_node, end_node = nil)
+    # Find all nodes after start_node, optionally bounded by end_node.
     # (following-siblings only works when nodes are at the same level)
-    nodes_between = start_node.xpath("following::*") & end_node.xpath("preceding::*")
+    nodes_between = start_node.xpath("following::*")
+    nodes_between &= end_node.xpath("preceding::*") if end_node
 
     # Remove nodes whose parent is already included (UL>LI,P>EM etc)
     deduped_nodes = nodes_between.reject do |node|

--- a/app/services/find_accessibility_page_service.rb
+++ b/app/services/find_accessibility_page_service.rb
@@ -45,7 +45,7 @@ class FindAccessibilityPageService
 
     def required_headings_present?(current_page)
       matching_headings = current_page.headings.select do |heading|
-        Checks::AccessibilityPageHeading.expected_headings.any? do |required_heading|
+        AccessibilityDeclarationHeadings.expected_heading_titles.any? do |required_heading|
           fuzzy_match?(heading, required_heading)
         end
       end

--- a/app/services/find_accessibility_page_service.rb
+++ b/app/services/find_accessibility_page_service.rb
@@ -4,6 +4,8 @@ class FindAccessibilityPageService
   REQUIRED_DECLARATION_HEADINGS = 2
 
   class << self
+    include AccessibilityDeclarationHeadings
+
     def call(audit)
       queue = prioritize_queue!(url: audit.home_page_url, starting_html: audit.home_page_html)
       crawler = Crawler.new(audit.home_page_url, root_page_html: audit.home_page_html, queue: queue)
@@ -45,7 +47,7 @@ class FindAccessibilityPageService
 
     def required_headings_present?(current_page)
       matching_headings = current_page.headings.select do |heading|
-        AccessibilityDeclarationHeadings.expected_heading_titles.any? do |required_heading|
+        expected_declaration_heading_titles.any? do |required_heading|
           fuzzy_match?(heading, required_heading)
         end
       end

--- a/app/views/checks/_accessibility_page_heading.html.erb
+++ b/app/views/checks/_accessibility_page_heading.html.erb
@@ -39,7 +39,7 @@
         </li>
       <% end %>
     <% else %>
-      <% Checks::AccessibilityPageHeading::EXPECTED_HEADINGS.each do |level, heading| %>
+      <% AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.each do |level, heading| %>
         <li class="fr-mb-2w">
           <strong>
             <code>&lt;h<%= level %>&gt;</code>

--- a/spec/models/checks/accessibility_page_heading_spec.rb
+++ b/spec/models/checks/accessibility_page_heading_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
 
     let(:page_headings) { analyze[:page_headings] }
     let(:comparison) { analyze[:comparison] }
-    let(:expected_headings) { described_class::EXPECTED_HEADINGS }
+    let(:expected_headings) { AccessibilityDeclarationHeadings::EXPECTED_HEADINGS }
 
     before do
       check.audit = audit
@@ -141,7 +141,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
     context "when all headings are :ok" do
       let(:comparison_data) do
         {
-          comparison: described_class::EXPECTED_HEADINGS.map do |level, heading|
+          comparison: AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.map do |level, heading|
             [heading, level, :ok, heading]
           end
         }
@@ -155,7 +155,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
     context "when all headings are :missing" do
       let(:comparison_data) do
         {
-          comparison: described_class::EXPECTED_HEADINGS.map do |level, heading|
+          comparison: AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.map do |level, heading|
             [heading, level, :missing, nil]
           end
         }
@@ -171,7 +171,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
         {
           comparison: [
             ["État de conformité", 2, :incorrect_level, "État de conformité"],
-            *described_class::EXPECTED_HEADINGS[1..-1].map { |level, heading| [heading, level, :ok, heading] }
+            *AccessibilityDeclarationHeadings::EXPECTED_HEADINGS[1..-1].map { |level, heading| [heading, level, :ok, heading] }
           ]
         }
       end
@@ -186,7 +186,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
         {
           comparison: [
             ["État de conformité", 2, :incorrect_order, "État de conformité"],
-            *described_class::EXPECTED_HEADINGS[1..-1].map { |level, heading| [heading, level, :ok, heading] }
+            *AccessibilityDeclarationHeadings::EXPECTED_HEADINGS[1..-1].map { |level, heading| [heading, level, :ok, heading] }
           ]
         }
       end
@@ -225,7 +225,7 @@ RSpec.describe Checks::AccessibilityPageHeading do
     context "when half headings are :ok and half are :incorrect_level" do
       let(:comparison_data) do
         {
-          comparison: described_class::EXPECTED_HEADINGS.map.with_index do |(level, heading), index|
+          comparison: AccessibilityDeclarationHeadings::EXPECTED_HEADINGS.map.with_index do |(level, heading), index|
             status = index.even? ? :ok : :incorrect_level
             [heading, level, status, heading]
           end

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -28,33 +28,27 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
     it "extracts data from declaration sections using the next declaration heading" do
       body = <<~HTML
         <h1>Déclaration d’accessibilité</h1>
-        <p>Carrefour s’engage à rendre ses sites internet accessibles conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.</p>
         <h2>État de conformité</h2>
-        <p>Le site « Carrefour FR » est partiellement conforme avec le RGAA version 4.1.</p>
+        <p>Le service est partiellement conforme avec le RGAA version 4.1.</p>
         <h2>Résultats des tests</h2>
         <h3>Résultats des tests</h3>
-        <p>L’audit de conformité réalisé par la société <strong>IPEDIS</strong> révèle que :</p>
-        <p>Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% sur l’ensemble critères du référentiel générale d’amélioration de l’accessibilité (RGAA).</p>
-        <h2>Contenus non accessibles</h2>
-        <p>Plusieurs non-conformités ont été identifiées.</p>
+        <p>L’audit de conformité réalisé par la société <strong>AccessFacile</strong> révèle que :</p>
+        <p>Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% sur l’ensemble des critères du RGAA.</p>
         <h2>Retour d'information et contact</h2>
-        <h3>Contact</h3>
         <p>
           Pour toute question, écrire à
-          <a href="mailto:direction_communication_groupe@carrefour.com">direction_communication_groupe@carrefour.com</a>
+          <a href="mailto:contact@rond-point.example">contact@rond-point.example</a>
         </p>
         <h2>Voies de recours</h2>
-        <p>Vous pouvez contacter le Défenseur des droits.</p>
       HTML
 
       allow(check).to receive(:page).and_return(build(:page, body:))
 
       expect(check.send(:analyze!)).to include(
                                          compliance_rate: 71.21,
-                                         auditor: "IPEDIS",
+                                         auditor: "AccessFacile",
                                          standard: "RGAA version 4.1",
-                                         mentions_article: true,
-                                         contact_email: "direction_communication_groupe@carrefour.com"
+                                         contact_email: "contact@rond-point.example"
                                        )
     end
   end

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -24,6 +24,39 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
                                          mentions_article: true
                                        )
     end
+
+    it "extracts data from declaration sections using the next declaration heading" do
+      body = <<~HTML
+        <h1>Déclaration d’accessibilité</h1>
+        <p>Carrefour s’engage à rendre ses sites internet accessibles conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.</p>
+        <h2>État de conformité</h2>
+        <p>Le site « Carrefour FR » est partiellement conforme avec le RGAA version 4.1.</p>
+        <h2>Résultats des tests</h2>
+        <h3>Résultats des tests</h3>
+        <p>L’audit de conformité réalisé par la société <strong>IPEDIS</strong> révèle que :</p>
+        <p>Le taux global de conformité était de 51,43% en Juin 2023, mis à jour à 71,21% sur l’ensemble critères du référentiel générale d’amélioration de l’accessibilité (RGAA).</p>
+        <h2>Contenus non accessibles</h2>
+        <p>Plusieurs non-conformités ont été identifiées.</p>
+        <h2>Retour d'information et contact</h2>
+        <h3>Contact</h3>
+        <p>
+          Pour toute question, écrire à
+          <a href="mailto:direction_communication_groupe@carrefour.com">direction_communication_groupe@carrefour.com</a>
+        </p>
+        <h2>Voies de recours</h2>
+        <p>Vous pouvez contacter le Défenseur des droits.</p>
+      HTML
+
+      allow(check).to receive(:page).and_return(build(:page, body:))
+
+      expect(check.send(:analyze!)).to include(
+                                         compliance_rate: 71.21,
+                                         auditor: "IPEDIS",
+                                         standard: "RGAA version 4.1",
+                                         mentions_article: true,
+                                         contact_email: "direction_communication_groupe@carrefour.com"
+                                       )
+    end
   end
 
   describe "#find_contact_email" do

--- a/spec/models/checks/analyze_accessibility_page_spec.rb
+++ b/spec/models/checks/analyze_accessibility_page_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Checks::AnalyzeAccessibilityPage do
           Pour toute question, écrire à
           <a href="mailto:contact@rond-point.example">contact@rond-point.example</a>
         </p>
-        <h2>Voies de recours</h2>
       HTML
 
       allow(check).to receive(:page).and_return(build(:page, body:))

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -395,6 +395,7 @@ RSpec.describe Page do
             <h2>Second Heading</h2>
             <p>Content in second section</p>
             <h3>Third Heading</h3>
+            <p>Content in third section</p>
           HTML
         end
 
@@ -409,9 +410,9 @@ RSpec.describe Page do
         end
 
         context "when matched heading is the last heading" do
-          it "returns empty string" do
+          it "returns text until the end of the document" do
             result = page.text(between_headings: [/Third Heading/, :next])
-            expect(result).to eq("")
+            expect(result).to eq("Content in third section")
           end
         end
 
@@ -614,6 +615,8 @@ RSpec.describe Page do
             <a href="/link1">Link 1</a>
             <h2>Second Heading</h2>
             <a href="/link2">Link 2</a>
+            <h3>Third Heading</h3>
+            <a href="/link3">Link 3</a>
           HTML
 
           links = page.links(between_headings: [/First Heading/, :next])
@@ -621,11 +624,11 @@ RSpec.describe Page do
           expect(links.collect(&:text)).not_to include("Link 2")
         end
 
-        it "returns empty array when matched heading is the last heading" do
+        it "returns links until the end of the document when matched heading is the last heading" do
           page = build(:page, body: "<h1>Last Heading</h1><a href='/link'>Link</a>")
 
           links = page.links(between_headings: [/Last Heading/, :next])
-          expect(links).to eq([])
+          expect(links.collect(&:text)).to eq(["Link"])
         end
       end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -427,6 +427,7 @@ RSpec.describe Page do
       context "with :previous relative matcher" do
         let(:body) do
           <<~HTML
+            <p>Introduction text</p>
             <h1>First Heading</h1>
             <p>Content in first section</p>
             <h2>Second Heading</h2>
@@ -446,9 +447,9 @@ RSpec.describe Page do
         end
 
         context "when matched heading is the first heading" do
-          it "returns empty string" do
+          it "returns text from the start of the document" do
             result = page.text(between_headings: [:previous, /First Heading/])
-            expect(result).to eq("")
+            expect(result).to eq("Introduction text")
           end
         end
 
@@ -635,6 +636,7 @@ RSpec.describe Page do
       context "with :previous relative matcher" do
         it "returns links from previous heading to matched heading" do
           page = build(:page, body: <<~HTML)
+            <a href="/intro">Intro Link</a>
             <h1>First Heading</h1>
             <a href="/link1">Link 1</a>
             <h2>Second Heading</h2>
@@ -646,11 +648,11 @@ RSpec.describe Page do
           expect(links.collect(&:text)).not_to include("Link 2")
         end
 
-        it "returns empty array when matched heading is the first heading" do
-          page = build(:page, body: "<h1>First Heading</h1><a href='/link'>Link</a>")
+        it "returns links from the start of the document when matched heading is the first heading" do
+          page = build(:page, body: "<a href='/intro'>Intro Link</a><h1>First Heading</h1><a href='/link'>Link</a>")
 
           links = page.links(between_headings: [:previous, /First Heading/])
-          expect(links).to eq([])
+          expect(links.collect(&:text)).to eq(["Intro Link"])
         end
       end
 

--- a/spec/services/find_accessibility_page_service_spec.rb
+++ b/spec/services/find_accessibility_page_service_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe FindAccessibilityPageService do
   describe ".call" do
     let(:matching_page_url) { "https://example.com/accessibility" }
     let(:matching_page_html) do
-      "<html><body><h1>#{Checks::AccessibilityPageHeading.expected_headings[0]}</h1><h1>#{Checks::AccessibilityPageHeading.expected_headings[1]}</h1></body></html>"
+      "<html><body><h1>#{AccessibilityDeclarationHeadings.expected_heading_titles[0]}</h1><h1>#{AccessibilityDeclarationHeadings.expected_heading_titles[1]}</h1></body></html>"
     end
-    let(:matching_page) { instance_double(Page, url: matching_page_url, html: matching_page_html, headings: Checks::AccessibilityPageHeading.expected_headings.first(2)) }
+    let(:matching_page) { instance_double(Page, url: matching_page_url, html: matching_page_html, headings: AccessibilityDeclarationHeadings.expected_heading_titles.first(2)) }
     let(:crawler) { instance_double(Crawler) }
 
     before do

--- a/spec/services/find_accessibility_page_service_spec.rb
+++ b/spec/services/find_accessibility_page_service_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe FindAccessibilityPageService do
   describe ".call" do
     let(:matching_page_url) { "https://example.com/accessibility" }
     let(:matching_page_html) do
-      "<html><body><h1>#{AccessibilityDeclarationHeadings.expected_heading_titles[0]}</h1><h1>#{AccessibilityDeclarationHeadings.expected_heading_titles[1]}</h1></body></html>"
+      "<html><body><h1>#{described_class.expected_declaration_heading_titles[0]}</h1><h1>#{described_class.expected_declaration_heading_titles[1]}</h1></body></html>"
     end
-    let(:matching_page) { instance_double(Page, url: matching_page_url, html: matching_page_html, headings: AccessibilityDeclarationHeadings.expected_heading_titles.first(2)) }
+    let(:matching_page) { instance_double(Page, url: matching_page_url, html: matching_page_html, headings: described_class.expected_declaration_heading_titles.first(2)) }
     let(:crawler) { instance_double(Crawler) }
 
     before do


### PR DESCRIPTION
## Contexte

Sur certaines déclarations, l’extraction échoue car le découpage actuel s’appuie sur le heading HTML suivant, ce qui peut tronquer la section analysée.
exemple : 
<img width="1284" height="285" alt="Capture d’écran 2026-04-22 à 10 25 11" src="https://github.com/user-attachments/assets/cec255c6-7fe6-4aaa-8547-09ef492b0b8c" />


## Changements

- ajout d’un découpage métier basé sur les headings attendus d’une déclaration
- extraction du contenu entre un heading de déclaration et le prochain heading de déclaration reconnu dans la page
- factorisation des headings attendus dans `AccessibilityDeclarationHeadings`

## Effet

Corrige le cas de ce site et tout autre page ayant des sous-header dans la déclaration sans modifier le comportement générique de `Page`.