### PR TITLE
chore: bundle update mcp to fix security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
       rouge (~> 4)
       securerandom
     matrix (0.4.3)
-    mcp (0.8.0)
+    mcp (0.13.0)
       json-schema (>= 4.1)
     memoist3 (1.0.0)
     memory_profiler (1.1.0)


### PR DESCRIPTION
There is a serious security issue with the current version of the dependency 'MCP' used in Rubocop
"bundle update mcp" fix the issue
Rubocop is still working