### PR TITLE
chore: Add migration to backfill `site` URLs (#553)

### DIFF
--- a/db/migrate/20260420142312_backfill_site_urls.rb
+++ b/db/migrate/20260420142312_backfill_site_urls.rb
@@ -1,0 +1,25 @@
+class BackfillSiteUrls < ActiveRecord::Migration[8.1]
+  def up
+    Site.includes(:audits).find_in_batches do |sites|
+      sites.each do |site|
+        audit_url = site.audits.first&.url
+        next if audit_url.blank?
+        normalized_url = Link.url_without_scheme_and_www(audit_url)
+
+        # update_columns here is needed because of an overriding url setter method in Site model
+        site.update_columns(url: audit_url, normalized_url:, updated_at: Time.zone.now)
+      end
+    end
+  end
+
+  def down
+    Audit.includes(:site).find_in_batches do |audits|
+      audits.each do |audit|
+        site_url = audit.site&.url
+        next if site_url.blank? || audit.url.present?
+
+        audit.update(url: site_url)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_133945) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_142312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
- Populate `url` and `normalized_url` in `site` using `audit` `url`.
Using `normalized_url = Link.url_without_scheme_and_www(audit_url)` because the whole logic is too heavy to reimplem.