### PR TITLE
chore: Add migration to backfill `site` URLs

### DIFF
--- a/app/controllers/concerns/sites_filtering.rb
+++ b/app/controllers/concerns/sites_filtering.rb
@@ -1,8 +1,8 @@
 module SitesFiltering
   extend ActiveSupport::Concern
 
-  DEFAULT_DIRECTION = "desc"
-  SORT_DIRECTIONS = %w[asc desc].freeze
+  DEFAULT_DIRECTION = :desc
+  SORT_DIRECTIONS = %i[asc desc].freeze
 
   private
 
@@ -38,21 +38,15 @@ module SitesFiltering
   end
 
   def order_sites(scope)
-    if sort_by_url?
-      order_by_url(scope)
-    else
-      order_by_completed_at(scope)
-    end
+    sort_by_url? ? order_by_url(scope) : order_by_completed_at(scope)
   end
 
   def order_by_completed_at(scope)
-    direction = sort_direction.upcase
-    scope.order("audits.completed_at #{direction} NULLS LAST, sites.created_at #{direction}")
+    scope.order("audits.completed_at #{sort_direction.upcase} NULLS LAST, sites.created_at #{sort_direction.upcase}")
   end
 
   def order_by_url(scope)
-    direction = sort_direction.upcase
-    scope.order("sites.normalized_url #{direction} NULLS LAST, sites.created_at #{direction}")
+    scope.order(normalized_url: sort_direction)
   end
 
   def sort_by_url?
@@ -62,6 +56,9 @@ module SitesFiltering
   def sort_direction
     direction = params.dig(:sort, :url).presence || params.dig(:sort, :completed_at).presence
 
+    return DEFAULT_DIRECTION if direction.blank?
+
+    direction = direction.to_sym
     direction.in?(SORT_DIRECTIONS) ? direction : DEFAULT_DIRECTION
   end
 

--- a/app/controllers/concerns/sites_filtering.rb
+++ b/app/controllers/concerns/sites_filtering.rb
@@ -25,7 +25,7 @@ module SitesFiltering
     term = "%#{search_query}%"
 
     scope.where(
-      "sites.name ILIKE ? OR audits.url ILIKE ?",
+      "sites.name ILIKE ? OR sites.url ILIKE ?",
       term,
       term
     )
@@ -51,11 +51,8 @@ module SitesFiltering
   end
 
   def order_by_url(scope)
-    scope.order(
-      Arel.sql(
-        "REGEXP_REPLACE(audits.url, '^https?://(www\\.)?', '') #{sort_direction.upcase}"
-      )
-    )
+    direction = sort_direction.upcase
+    scope.order("sites.normalized_url #{direction} NULLS LAST, sites.created_at #{direction}")
   end
 
   def sort_by_url?

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -40,18 +40,21 @@ class SitesController < ApplicationController
 
   # POST /sites
   def create
-    url = site_params[:url]
-    @site = current_user.team.sites.find_by_url(url:) || current_user.team.sites.build
-    @site.assign_attributes(site_params)
-    notice = if @site.new_record?
-      t(".created")
+    normalized_url = Link.url_without_scheme_and_www(site_params[:url])
+    @site = current_user.team.sites.find_by(normalized_url:)
+
+    if @site
+      @site.audit!
+      redirect_to @site, notice: t(".new_audit")
     else
-      t(".new_audit")
-    end
-    if @site.save
-      redirect_to @site, notice:
-    else
-      render :new, status: :unprocessable_content
+      @site = current_user.team.sites.build(site_params)
+
+      if @site.save
+        @site.audit!
+        redirect_to @site, notice: t(".created")
+      else
+        render :new, status: :unprocessable_content
+      end
     end
   end
 
@@ -107,7 +110,7 @@ class SitesController < ApplicationController
   end
 
   def set_site
-    @site = sites_scope.preloaded.friendly.find(params.expect(:id))
+    @site = current_user.team.sites.friendly.find(params.expect(:id))
   end
 
   def set_sites

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -110,7 +110,7 @@ class SitesController < ApplicationController
   end
 
   def set_site
-    @site = current_user.team.sites.friendly.find(params.expect(:id))
+    @site = sites_scope.preloaded.friendly.find(params.expect(:id))
   end
 
   def set_sites

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -51,7 +51,7 @@ class SiteCsvExport
         axe = audit&.run_axe_on_homepage
 
         row = [
-          site.url_without_scheme_and_www,
+          site.normalized_url,
           site.name,
           site.url,
           audit.reachable.redirect_url,

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -99,7 +99,7 @@ class Audit < ApplicationRecord
   def build_page(kind, page_url)
     snapshot_html = html_for(kind)
 
-    Page.new(url: page_url, root: site.url, html: snapshot_html)
+    Page.new(url: page_url, root: home_page_url, html: snapshot_html)
   end
 
   def page_url_for(kind)

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -8,7 +8,6 @@ class Audit < ApplicationRecord
   normalizes :url, with: ->(url) { Link.normalize(url).to_s }
 
   scope :sort_by_newest, -> { order(created_at: :desc) }
-  scope :sort_by_url, -> { order(Arel.sql("REGEXP_REPLACE(audits.url, '^https?://(www\.)?', '') ASC")) }
   scope :completed, -> { where.not(completed_at: nil) }
   scope :current, -> { where(current: true) }
   scope :with_check_transitions, -> { includes(checks: :check_transitions) }
@@ -100,15 +99,15 @@ class Audit < ApplicationRecord
   def build_page(kind, page_url)
     snapshot_html = html_for(kind)
 
-    Page.new(url: page_url, root: url, html: snapshot_html)
+    Page.new(url: page_url, root: site.url, html: snapshot_html)
   end
 
   def page_url_for(kind)
     case kind
     when :home
-      url
+      home_page_url
     when :accessibility
-      find_accessibility_page&.url
+      accessibility_page_url
     else
       raise ArgumentError, "Don't know how to find a page of kind '#{kind}'"
     end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -51,7 +51,6 @@ class Check < ApplicationRecord
   belongs_to :audit
   has_one :site, through: :audit
 
-  delegate :parsed_url, to: :audit
   delegate :human_type, to: :class
 
   after_initialize :set_priority

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -8,7 +8,9 @@ module Checks
     def redirected?
       return if audit.home_page_url.blank?
 
-      normalize(audit.home_page_url) != normalize(site.url)
+      normalized_audit_url = Link.url_without_scheme_and_www(audit.home_page_url)
+
+      normalized_audit_url != site.normalized_url
     end
 
     def custom_badge_text
@@ -35,17 +37,6 @@ module Checks
       else
         {}
       end
-    end
-
-    def normalize(url)
-      parsed = Link.parse(url.downcase)
-      host = parsed.host.start_with?("www.") ? parsed.host[4..-1] : parsed.host
-      {
-        host: host,
-        path: parsed.path,
-        query: parsed.query,
-        fragment: parsed.fragment
-      }
     end
   end
 end

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -8,7 +8,7 @@ module Checks
     def redirected?
       return if audit.home_page_url.blank?
 
-      normalize(audit.home_page_url) != normalize(audit.url)
+      normalize(audit.home_page_url) != normalize(site.url)
     end
 
     def custom_badge_text
@@ -31,7 +31,7 @@ module Checks
       site.update(name: root_page.title) if site && site.name.blank?
 
       if redirected?
-        { original_url: audit.url, redirect_url: audit.home_page_url }
+        { original_url: site.url, redirect_url: audit.home_page_url }
       else
         {}
       end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -10,46 +10,21 @@ class Site < ApplicationRecord
   scope :with_current_audit, -> { joins(:audits).merge(Audit.current) }
   scope :preloaded, -> { with_current_audit.includes(:tags, :slugs, audits: { checks: :check_transitions }) }
 
+  before_validation :set_normalized_url, if: :will_save_change_to_url?
   after_save :set_current_audit!, unless: -> { audits_count == audits_count_before_last_save }
 
-  friendly_id :url_without_scheme_and_www, use: [:slugged, :history, :scoped], scope: :team_id
-
-  delegate :url, to: :audit, allow_nil: true
+  friendly_id :normalized_url, use: [:slugged, :history, :scoped], scope: :team_id
 
   validates :url, presence: true, url: true
 
   broadcasts_refreshes
 
-  class << self
-    def find_by_url(attributes)
-      url = attributes.to_h.fetch(:url).strip
-      return if url.empty?
-
-      # Ignore http/https duplicates when searching
-      normalized_url = [url, url.sub(/^https?/, url.start_with?("https") ? "http" : "https")]
-      joins(:audits).find_by(audits: { url: normalized_url })
-    end
-  end
-
-  def url=(new_url)
-    return if url == new_url
-
-    if audit.pending?
-      audit.url = new_url
-      audit.save if audit.persisted?
-    else
-      audits.build(url: new_url)
-    end
-
-    persist_site_urls!(new_url)
-  end
-
-  def url_without_scheme_and_www
-    Link.url_without_scheme_and_www(audit.url)
+  def set_normalized_url
+    self.normalized_url = Link.url_without_scheme_and_www(url)
   end
 
   def name_with_fallback
-    name.presence || url_without_scheme_and_www
+    name.presence || normalized_url
   end
 
   alias to_title name_with_fallback
@@ -62,7 +37,7 @@ class Site < ApplicationRecord
   end
 
   def should_generate_new_friendly_id?
-    new_record? || (slug != url_without_scheme_and_www.parameterize) || super
+    new_record? || (slug != normalized_url.parameterize) || super
   end
 
   def update_slug!
@@ -93,12 +68,5 @@ class Site < ApplicationRecord
 
   def tags_list
     tags.collect(&:name).join(", ")
-  end
-
-  private
-
-  def persist_site_urls!(url)
-    self[:url] = url
-    self[:normalized_url] = Link.url_without_scheme_and_www(url)
   end
 end

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -83,12 +83,12 @@ class SiteUpload
       rescue Link::InvalidUriError => error
         Rails.logger.warn(
           "site_upload_invalid_url " \
-            "team_id=#{team&.id} " \
-            "filename=#{file&.original_filename} " \
-            "line_number=#{line_number} " \
-            "raw_url=#{raw_url} " \
-            "error_class=#{error.class.name} " \
-            "error_message=#{error.message}"
+          "team_id=#{team&.id} " \
+          "filename=#{file&.original_filename} " \
+          "line_number=#{line_number} " \
+          "raw_url=#{raw_url} " \
+          "error_class=#{error.class.name} " \
+          "error_message=#{error.message}"
         )
         errors.add(:file, :invalid_row_url, line_number:, url: raw_url)
         next
@@ -111,10 +111,10 @@ class SiteUpload
   rescue CSV::MalformedCSVError => error
     Rails.logger.warn(
       "site_upload_malformed_csv " \
-        "team_id=#{team&.id} " \
-        "filename=#{file&.original_filename} " \
-        "error_class=#{error.class.name} " \
-        "error_message=#{error.message}"
+      "team_id=#{team&.id} " \
+      "filename=#{file&.original_filename} " \
+      "error_class=#{error.class.name} " \
+      "error_message=#{error.message}"
     )
     errors.add(:file, :malformed_csv)
   end

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -40,9 +40,10 @@ class SiteUpload
     return false if errors.any?
 
     transaction do
-      create!(new_sites.values) if new_sites.any?
+      create!(new_sites.values).each(&:audit!) if new_sites.any?
       existing_sites.values.each { |site| site.save && site.audit! }
     end
+
     true
   end
 
@@ -82,12 +83,12 @@ class SiteUpload
       rescue Link::InvalidUriError => error
         Rails.logger.warn(
           "site_upload_invalid_url " \
-          "team_id=#{team&.id} " \
-          "filename=#{file&.original_filename} " \
-          "line_number=#{line_number} " \
-          "raw_url=#{raw_url} " \
-          "error_class=#{error.class.name} " \
-          "error_message=#{error.message}"
+            "team_id=#{team&.id} " \
+            "filename=#{file&.original_filename} " \
+            "line_number=#{line_number} " \
+            "raw_url=#{raw_url} " \
+            "error_class=#{error.class.name} " \
+            "error_message=#{error.message}"
         )
         errors.add(:file, :invalid_row_url, line_number:, url: raw_url)
         next
@@ -97,7 +98,7 @@ class SiteUpload
 
       row_tag_ids = tag_names.map { |n| team.tags.find_or_create_by(name: n).id }
       combined_tag_ids = (tag_ids + row_tag_ids).uniq
-      existing_site = team.sites.find_by_url(url:)
+      existing_site = team.sites.find_by(url:)
 
       if existing_site
         existing_site.assign_attributes(tag_ids: combined_tag_ids.union(existing_site.tag_ids))
@@ -110,10 +111,10 @@ class SiteUpload
   rescue CSV::MalformedCSVError => error
     Rails.logger.warn(
       "site_upload_malformed_csv " \
-      "team_id=#{team&.id} " \
-      "filename=#{file&.original_filename} " \
-      "error_class=#{error.class.name} " \
-      "error_message=#{error.message}"
+        "team_id=#{team&.id} " \
+        "filename=#{file&.original_filename} " \
+        "error_class=#{error.class.name} " \
+        "error_message=#{error.message}"
     )
     errors.add(:file, :malformed_csv)
   end

--- a/app/services/fetch_home_page_service.rb
+++ b/app/services/fetch_home_page_service.rb
@@ -4,7 +4,7 @@ class FetchHomePageService
   class << self
     def call(audit)
       Browser
-        .get(audit.url)
+        .get(audit.site.url)
         .then do |response|
         Rails.logger.silence do
           audit.update_home_page!(response[:current_url], response[:body])

--- a/app/services/find_accessibility_page_service.rb
+++ b/app/services/find_accessibility_page_service.rb
@@ -30,7 +30,7 @@ class FindAccessibilityPageService
     def enqueue_children(page, queue, audit)
       excluded_targets = [
         page.url,
-        audit.url,
+        audit.site.url,
         audit.home_page_url
       ].compact.map { |url| Link.url_without_scheme_and_www(url) }.uniq
 

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,7 +1,7 @@
 <tr id="<%= dom_id(site, :sites_table) %>">
   <%= dsfr_row_check(site) %>
   <td class="fr-cell--center"><%= link_icon(:article, t('.view_name', name: site.name_with_fallback), url_for([site, site.audit]), title: t('.view_name', name: site.name_with_fallback), line: true, side: :left, sr_only: true) %></td>
-  <% display_url = site.url_without_scheme_and_www %>
+  <% display_url = site.normalized_url %>
   <% truncated_url = display_url.truncate(ApplicationHelper::TRUNCATION_LENGTH, separator: /\W/) %>
   <% href = Link.safe_external_url(site.url) %>
   <td>

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -155,7 +155,7 @@ Alors("la page contient un tableau") do
 end
 
 Alors("la page contient toutes les vérifications du site {string} avec le préfixe {string}") do |url, prefix|
-  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
+  site = team.sites.find_by(url:)
   expect(page).to have_css("table") if prefix.present?
   site.audit.checks.each do |check|
     expect(page).to have_content(check.class.table_header)
@@ -163,7 +163,7 @@ Alors("la page contient toutes les vérifications du site {string} avec le préf
 end
 
 Alors("la page contient un tableau avec toutes les vérifications du site {string}") do |url|
-  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
+  site = team.sites.find_by(url:)
   expect(page).to have_css("table")
   site.audit.checks.each do |check|
     expect(page).to have_content(check.table_header)
@@ -171,7 +171,7 @@ Alors("la page contient un tableau avec toutes les vérifications du site {strin
 end
 
 Alors("la page contient toutes les vérifications du site {string}") do |url|
-  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
+  site = team.sites.find_by(url:)
   site.audit.checks.each do |check|
     expect(page).to have_content(check.human_type)
   end

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -24,49 +24,49 @@ end
 # NICE and we should do something about it soon.
 Sachantque("le site {string} renvoie une réponse HTML normale pour la page d'accueil") do |url|
   fake_html = <<~HTML
-    <html>
-      <head>
-        <title>Site title</title>
-      </head>
-      <body>
-        <h1>Hello</h1>
-      </body>
-    </html>
-  HTML
+        <html>
+          <head>
+            <title>Site title</title>
+          </head>
+          <body>
+            <h1>Hello</h1>
+          </body>
+        </html>
+      HTML
 
   allow(Browser)
     .to receive(:get)
-          .with(url)
-          .and_return(
-            body: fake_html,
-            status: 200,
-            content_type: "text/html",
-            current_url: url
-          )
+    .with(url)
+    .and_return(
+      body: fake_html,
+      status: 200,
+      content_type: "text/html",
+      current_url: url
+    )
 end
 
 Sachantque("le site {string} renvoie {string} pour la page d'accueil") do |url, html|
   allow(Browser)
     .to receive(:get)
-          .with(url)
-          .and_return(
-            body: html,
-            status: 200,
-            content_type: "text/html",
-            current_url: url
-          )
+    .with(url)
+    .and_return(
+      body: html,
+      status: 200,
+      content_type: "text/html",
+      current_url: url
+    )
 end
 
 Sachantque("l'adresse {string} renvoie {string}") do |url, html|
   allow(Browser)
     .to receive(:get)
-          .with(url)
-          .and_return(
-            body: html,
-            status: 200,
-            content_type: "text/html",
-            current_url: url
-          )
+    .with(url)
+    .and_return(
+      body: html,
+      status: 200,
+      content_type: "text/html",
+      current_url: url
+    )
 end
 
 Sachantque("le site {string} renvoie {string} pour la déclaration d'accessibilité") do |url, str|
@@ -76,26 +76,26 @@ end
 Sachantque("le site {string} renvoie {string} à l'adresse {string} pour la déclaration d'accessibilité") do |_url, str, declaration_url|
   allow(FindAccessibilityPageService)
     .to receive(:find_page)
-          .and_return(Page.new(url: declaration_url, root: declaration_url, html: str))
+    .and_return(Page.new(url: declaration_url, root: declaration_url, html: str))
 end
 
 Quand("le site {string} ne trouve pas de page d'accessibilité") do |string|
   allow(FindAccessibilityPageService)
     .to receive(:find_page)
-          .and_return(nil)
+    .and_return(nil)
 end
 
 Sachantque("le site {string} renvoie une réponse HTML normale pour la déclaration d'accessibilité") do |url|
   fake_html = <<~HTML
-    <html>
-      <head>
-        <title>Site title</title>
-      </head>
-      <body>
-        <h1>Hello</h1>
-      </body>
-    </html>
-  HTML
+        <html>
+          <head>
+            <title>Site title</title>
+          </head>
+          <body>
+            <h1>Hello</h1>
+          </body>
+        </html>
+      HTML
 
   step(%(le site "#{url}" renvoie "#{fake_html}" pour la déclaration d'accessibilité))
 end

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -24,51 +24,50 @@ end
 # NICE and we should do something about it soon.
 Sachantque("le site {string} renvoie une réponse HTML normale pour la page d'accueil") do |url|
   fake_html = <<~HTML
-        <html>
-          <head>
-            <title>Site title</title>
-          </head>
-          <body>
-            <h1>Hello</h1>
-          </body>
-        </html>
-      HTML
+    <html>
+      <head>
+        <title>Site title</title>
+      </head>
+      <body>
+        <h1>Hello</h1>
+      </body>
+    </html>
+  HTML
 
   allow(Browser)
     .to receive(:get)
-    .with(url)
-    .and_return(
-      body: fake_html,
-      status: 200,
-      content_type: "text/html",
-      current_url: url
-    )
+          .with(url)
+          .and_return(
+            body: fake_html,
+            status: 200,
+            content_type: "text/html",
+            current_url: url
+          )
 end
 
 Sachantque("le site {string} renvoie {string} pour la page d'accueil") do |url, html|
   allow(Browser)
     .to receive(:get)
-    .with(url)
-    .and_return(
-      body: html,
-      status: 200,
-      content_type: "text/html",
-      current_url: url
-    )
+          .with(url)
+          .and_return(
+            body: html,
+            status: 200,
+            content_type: "text/html",
+            current_url: url
+          )
 end
 
 Sachantque("l'adresse {string} renvoie {string}") do |url, html|
   allow(Browser)
     .to receive(:get)
-    .with(url)
-    .and_return(
-      body: html,
-      status: 200,
-      content_type: "text/html",
-      current_url: url
-    )
+          .with(url)
+          .and_return(
+            body: html,
+            status: 200,
+            content_type: "text/html",
+            current_url: url
+          )
 end
-
 
 Sachantque("le site {string} renvoie {string} pour la déclaration d'accessibilité") do |url, str|
   step(%(le site "#{url}" renvoie "#{str}" à l'adresse "#{url}/accessibilité" pour la déclaration d'accessibilité))
@@ -77,26 +76,26 @@ end
 Sachantque("le site {string} renvoie {string} à l'adresse {string} pour la déclaration d'accessibilité") do |_url, str, declaration_url|
   allow(FindAccessibilityPageService)
     .to receive(:find_page)
-    .and_return(Page.new(url: declaration_url, root: declaration_url, html: str))
+          .and_return(Page.new(url: declaration_url, root: declaration_url, html: str))
 end
 
 Quand("le site {string} ne trouve pas de page d'accessibilité") do |string|
   allow(FindAccessibilityPageService)
     .to receive(:find_page)
-    .and_return(nil)
+          .and_return(nil)
 end
 
 Sachantque("le site {string} renvoie une réponse HTML normale pour la déclaration d'accessibilité") do |url|
   fake_html = <<~HTML
-        <html>
-          <head>
-            <title>Site title</title>
-          </head>
-          <body>
-            <h1>Hello</h1>
-          </body>
-        </html>
-      HTML
+    <html>
+      <head>
+        <title>Site title</title>
+      </head>
+      <body>
+        <h1>Hello</h1>
+      </body>
+    </html>
+  HTML
 
   step(%(le site "#{url}" renvoie "#{fake_html}" pour la déclaration d'accessibilité))
 end
@@ -128,7 +127,7 @@ Quand("je possède un site {string} avec des données") do |url|
 end
 
 Quand("le site {string} a les étiquettes {string}") do |url, tags_str|
-  site = team.sites.find_by_url(url:)
+  site = team.sites.find_by(url:)
   tag_names = tags_str.split(",").map(&:strip)
   tag_names.each do |name|
     tag = FactoryBot.create(:tag, name:, team:)
@@ -137,7 +136,7 @@ Quand("le site {string} a les étiquettes {string}") do |url, tags_str|
 end
 
 Quand("je demande une nouvelle vérification du site {string}") do |url|
-  site = team.sites.find_by_url(url:)
+  site = team.sites.find_by(url:)
   site.audits.create!(url: site.url, current: false)
 end
 
@@ -156,7 +155,7 @@ Alors("la page contient un tableau") do
 end
 
 Alors("la page contient toutes les vérifications du site {string} avec le préfixe {string}") do |url, prefix|
-  site = team.sites.find_by_url(url:)
+  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
   expect(page).to have_css("table") if prefix.present?
   site.audit.checks.each do |check|
     expect(page).to have_content(check.class.table_header)
@@ -164,7 +163,7 @@ Alors("la page contient toutes les vérifications du site {string} avec le préf
 end
 
 Alors("la page contient un tableau avec toutes les vérifications du site {string}") do |url|
-  site = team.sites.find_by_url(url:)
+  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
   expect(page).to have_css("table")
   site.audit.checks.each do |check|
     expect(page).to have_content(check.table_header)
@@ -172,7 +171,7 @@ Alors("la page contient un tableau avec toutes les vérifications du site {strin
 end
 
 Alors("la page contient toutes les vérifications du site {string}") do |url|
-  site = team.sites.find_by_url(url:)
+  site = team.sites.find_by(normalized_url: Link.url_without_scheme_and_www(url))
   site.audit.checks.each do |check|
     expect(page).to have_content(check.human_type)
   end

--- a/spec/export/site_csv_export_spec.rb
+++ b/spec/export/site_csv_export_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe SiteCsvExport do
         row = parsed_csv.first
         audit = site.audit.reload
 
-        expect(row["Adresse du site"]).to eq(site.url_without_scheme_and_www)
+        expect(row["Adresse du site"]).to eq(site.normalized_url)
         expect(row["Nom du site"]).to eq(site.name)
-        expect(row["URL"]).to eq(audit.url)
+        expect(row["URL"]).to eq(site.url)
         expect(row["URL de redirection"]).to be_nil
         expect(row["Toutes les étiquettes"]).to eq(tags.collect(&:name).join(", "))
         expect(row["Vérification effectuée le"]).to eq(audit.completed_at.to_s)

--- a/spec/jobs/fetch_resources_job_spec.rb
+++ b/spec/jobs/fetch_resources_job_spec.rb
@@ -41,7 +41,7 @@ describe FetchResourcesJob do
     end
 
     context "when the ressource does not exist" do
-      let(:error) { Ferrum::StatusError.new(audit.url) }
+      let(:error) { Ferrum::StatusError.new(audit.site.url) }
 
       it "does not crash" do
         expect { fetch_resources_job }.not_to raise_error

--- a/spec/jobs/run_check_job_spec.rb
+++ b/spec/jobs/run_check_job_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe RunCheckJob do
         instance.save!
       end
       allow(Browser).to receive(:get)
-                          .with(normalized_url)
                           .and_return({ body:, status:, content_type:, current_url: normalized_url })
     end
 
@@ -42,7 +41,6 @@ RSpec.describe RunCheckJob do
         instance.save!
       end
       allow(Browser).to receive(:get)
-                          .with(normalized_url)
                           .and_return({ body:, status:, content_type:, current_url: normalized_url })
     end
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -64,11 +64,8 @@ RSpec.describe Audit do
       let(:kind) { :accessibility }
 
       context "when find_accessibility_page check has a url" do
-        let(:accessibility_url) { "#{site.url}/accessibilite" }
-
-        before do
-          audit.accessibility_page_url = accessibility_url
-        end
+        let(:accessibility_url) { "https://example.com/accessibility" }
+        let(:audit) { create(:audit, :without_checks, site:, home_page_url: site.url, accessibility_page_url: accessibility_url) }
 
         it "creates a Page with the accessibility page url" do
           expect(Page).to receive(:new).with(url: accessibility_url, root: site.url, html: nil)
@@ -81,7 +78,7 @@ RSpec.describe Audit do
       end
 
       context "when find_accessibility_page check has no url" do
-        before { audit.accessibility_page_url = nil }
+        let(:accessibility_url) { nil }
 
         it "returns nil" do
           expect(page).to be_nil

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -34,20 +34,13 @@ RSpec.describe Audit do
 
       expect(described_class.sort_by_newest).to eq([newer, older, oldest])
     end
-
-    it ".sort_by_url orders by URL ignoring protocol and www" do
-      gamma = create(:audit, site:, url: "https://www.gamma.com")
-      alpha = create(:audit, site:, url: "https://alpha.com/path")
-      beta = create(:audit, site:, url: "http://www.beta.com")
-
-      expect(described_class.sort_by_url).to eq([alpha, beta, gamma])
-    end
   end
 
   describe "#page" do
     subject(:page) { audit.page(kind) }
 
-    let(:audit) { create(:audit, :without_checks, url: "https://example.com") }
+    let(:site) { create(:site, url: "https://example.com") }
+    let(:audit) { create(:audit, :without_checks, site:, home_page_url: site.url, accessibility_page_url: nil) }
     let(:mock_page) { instance_double(Page, html: nil) }
 
     before do
@@ -57,8 +50,8 @@ RSpec.describe Audit do
     context "when kind is :home" do
       let(:kind) { :home }
 
-      it "creates a Page with the audit url" do
-        expect(Page).to receive(:new).with(url: audit.url, root: audit.url, html: nil)
+      it "creates a Page with the site url" do
+        expect(Page).to receive(:new).with(url: site.url, root: site.url, html: nil)
         page
       end
 
@@ -71,14 +64,14 @@ RSpec.describe Audit do
       let(:kind) { :accessibility }
 
       context "when find_accessibility_page check has a url" do
-        let(:check) { instance_double(Checks::FindAccessibilityPage, url: "#{audit.url}/accessibilite") }
+        let(:accessibility_url) { "#{site.url}/accessibilite" }
 
         before do
-          allow(audit).to receive(:find_accessibility_page).and_return(check)
+          audit.accessibility_page_url = accessibility_url
         end
 
         it "creates a Page with the accessibility page url" do
-          expect(Page).to receive(:new).with(url: "#{audit.url}/accessibilite", root: audit.url, html: nil)
+          expect(Page).to receive(:new).with(url: accessibility_url, root: site.url, html: nil)
           page
         end
 
@@ -88,11 +81,7 @@ RSpec.describe Audit do
       end
 
       context "when find_accessibility_page check has no url" do
-        let(:check) { instance_double(Checks::FindAccessibilityPage, url: nil) }
-
-        before do
-          allow(audit).to receive(:find_accessibility_page).and_return(check)
-        end
+        before { audit.accessibility_page_url = nil }
 
         it "returns nil" do
           expect(page).to be_nil
@@ -100,10 +89,6 @@ RSpec.describe Audit do
       end
 
       context "when find_accessibility_page check does not exist" do
-        before do
-          allow(audit).to receive(:find_accessibility_page).and_return(nil)
-        end
-
         it "returns nil" do
           expect(page).to be_nil
         end
@@ -186,11 +171,8 @@ RSpec.describe Audit do
   end
 
   describe "after_create callback" do
-    let(:audit) { build(:audit) }
-
-    it "calls create_checks when audit is created" do
-      expect(audit).to receive(:create_checks).and_call_original
-      expect { audit.save! }.to change(Check, :count).by(Check.types.size)
+    it "creates checks when audit is created" do
+      expect { create(:audit) }.to change(Check, :count).by(Check.types.size)
     end
   end
 

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Check do
   end
 
   describe "delegations" do
-    it { is_expected.to delegate_method(:parsed_url).to(:audit) }
     it { is_expected.to delegate_method(:human_type).to(:class) }
   end
 
@@ -45,10 +44,12 @@ RSpec.describe Check do
   end
 
   describe "#root_page" do
-    it "returns a Page with the audit URL" do
-      audit = build(:audit, url: "https://example.com/")
-      check = build(:check, :accessibility_mention, audit:)
-      expect(Page).to receive(:new).with(url: "https://example.com/", root: "https://example.com/", html: nil)
+    let(:site) { create(:site, url: "https://example.com/") }
+    let(:audit) { create(:audit, site:, home_page_url: "https://example.com/", accessibility_page_url: nil) }
+    let(:check) { build(:check, :accessibility_mention, audit:) }
+
+    it "returns a Page with the site URL" do
+      expect(Page).to receive(:new).with(url: audit.home_page_url, root: audit.home_page_url, html: nil)
       check.root_page
     end
   end

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Checks::Reachable do
   let(:check) { described_class.new }
   let(:original_url) { "https://example.com" }
   let(:home_page_url) { original_url }
-  let(:audit) { instance_double(Audit, home_page_url:, update!: true) }
   let(:root_page) { instance_double(Page, html: nil) }
-  let(:site) { build(:site, url: original_url) }
+  let(:site) { create(:site, url: original_url) }
+  let(:audit) { build(:audit, site:, home_page_url:) }
 
   before do
     allow(check).to receive_messages(audit:, root_page:, site:)

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Checks::Reachable do
   let(:check) { described_class.new }
   let(:original_url) { "https://example.com" }
   let(:home_page_url) { original_url }
-  let(:audit) { instance_double(Audit, url: original_url, home_page_url:, update!: true) }
+  let(:audit) { instance_double(Audit, home_page_url:, update!: true) }
   let(:root_page) { instance_double(Page, html: nil) }
-  let(:site) { build(:site) }
+  let(:site) { build(:site, url: original_url) }
 
   before do
     allow(check).to receive_messages(audit:, root_page:, site:)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,85 +15,20 @@ RSpec.describe Site do
     it { is_expected.to have_many(:tags).through(:site_tags) }
   end
 
-  describe "delegations" do
-    it { is_expected.to delegate_method(:url).to(:audit) }
-
-    it "delegates to the most recent audit" do
-      site = create(:audit, url: "https://example.com").site
-      new_audit = create(:audit, site:, url: "https://new-example.com")
-      expect(site.reload.url).to eq(new_audit.url)
-    end
-  end
-
-  describe ".find_by_url" do
-    context "when url is malformed" do
-      it "returns nil" do
-        expect(described_class.find_by_url(url: "not a valid url")).to be_nil
-      end
-    end
-
-    context "when nothing exists for that URL" do
-      it "returns nil" do
-        expect(described_class.find_by_url(url: "http://not-an-existing-site.com")).to be_nil
-      end
-    end
-
-    context "when a site exists for that URL" do
-      let!(:existing_site) { create(:site, url:) }
-
-      it "returns existing site" do
-        expect(described_class.find_by_url(url:)).to eq(existing_site)
-      end
-    end
-
-    context "when a site exists with a different scheme" do
-      let!(:existing_site) { create(:site, url:) }
-
-      it "returns existing site" do
-        expect(described_class.find_by_url(url: url.sub("https:", "http:"))).to eq(existing_site)
-      end
-    end
-
-    context "when a site had that URL" do
-      let!(:existing_site) { create(:site, url:) }
-
-      it "finds site with historical URLs" do
-        new_url = "https://new-example.com"
-        existing_site.update(url: new_url)
-        expect(described_class.find_by_url(url: new_url)).to eq(existing_site)
-      end
-    end
-
-    context "when URL contains unicode" do
-      let!(:existing_site) { create(:site, url:) }
-      let(:url) { "https://éxâmplè.çôm/" }
-
-      it "returns the existing site" do
-        expect(described_class.find_by_url(url:)).to eq(existing_site)
-      end
-
-      it "finds by punycode url" do
-        punycode_url = Addressable::URI.parse(url).normalize.to_s
-        expect(described_class.find_by_url(url: punycode_url)).to eq(existing_site)
-      end
-    end
-  end
-
   describe "friendly_id" do
     let(:url) { "https://example.com/path?query=1" }
     let(:site) { create(:site, url:) }
 
-    it "generates slug from url_without_scheme_and_www" do
+    it "generates slug from normalized_url" do
       expect(site.slug).to be_present
-      expect(site.slug).to eq(site.url_without_scheme_and_www.parameterize)
+      expect(site.slug).to eq(site.normalized_url.parameterize)
     end
 
     it "maintains history of slugs" do
       old_slug = site.slug
       new_url = "https://new-example.com"
 
-      create(:audit, :completed, site:, url: new_url)
-      site.set_current_audit!
+      site.update!(url: new_url)
 
       expect(site.reload.slug).to eq("new-example-com")
       expect(described_class.friendly.find(old_slug)).to eq(site)
@@ -144,21 +79,23 @@ RSpec.describe Site do
       subject(:site) { create(:site) }
 
       it "marks the newest audit as current" do
-        old_audit = site.audit
+        old_audit = create(:audit, :current, site:)
         newest_audit = create(:audit, site:, completed_at: 1.day.ago)
         expect { site.set_current_audit! }.to change { newest_audit.reload.current }.from(false).to(true)
-          .and change { old_audit.reload.current }.from(true).to(false)
+                                                                                    .and change { old_audit.reload.current }.from(true).to(false)
       end
     end
 
     context "when the actual current audit is already marked as current" do
+      let!(:initial_audit) { create(:audit, :current, site:) }
+
       it "does not change anything" do
-        initial_audit.update(current: true)
         expect { site.set_current_audit! }.not_to change { initial_audit.reload.current }
       end
     end
 
     context "when there are incomplete audits only" do
+      let!(:initial_audit) { create(:audit, :current, site:) }
       let!(:newest_audit) { create(:audit, site:, completed_at: nil, created_at: 1.day.from_now) }
 
       it "marks the newest audit as current" do

--- a/spec/models/site_upload_spec.rb
+++ b/spec/models/site_upload_spec.rb
@@ -136,8 +136,7 @@ RSpec.describe SiteUpload do
     end
 
     it "skips sites that already exist" do
-      existing_site = build(:site, url: "https://example.com/")
-      allow(team.sites).to receive(:find_by_url) { |args| existing_site if args[:url] == "https://example.com/" }
+      existing_site = create(:site, url: "https://example.com/", team:)
 
       site_upload.parse_sites
 
@@ -185,17 +184,16 @@ RSpec.describe SiteUpload do
 
       expect(site_upload.new_sites.keys).to contain_exactly("https://example.com/", "https://test.com/")
       expect(site_upload.errors.details[:file]).to include(
-        error: :invalid_row_url, line_number: 3, url: "http://"
-      )
+                                                     error: :invalid_row_url, line_number: 3, url: "http://"
+                                                   )
       expect(site_upload.errors.details[:file]).to include(
-        error: :invalid_row_url, line_number: 4, url: "/contact"
-      )
+                                                     error: :invalid_row_url, line_number: 4, url: "/contact"
+                                                   )
       expect(Rails.logger).to have_received(:warn).twice
     end
 
     it "ignores duplicate existing sites" do
-      existing_site = build(:site, url: "https://example.com/")
-      allow(team.sites).to receive(:find_by_url) { |args| existing_site if args[:url] == "https://example.com/" }
+      existing_site = create(:site, url: "https://example.com/", team:)
 
       csv.write("url,name\nhttps://example.com/,Example Site\nhttps://example.com/,Example Site Again")
       csv.rewind

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Sites" do
 
       csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
       expect(csv.count).to eq(2)
-      expect(csv[0]["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
-      expect(csv[1]["Adresse du site"]).to eq(site.url_without_scheme_and_www)
+      expect(csv[0]["Adresse du site"]).to eq(other_site.normalized_url)
+      expect(csv[1]["Adresse du site"]).to eq(site.normalized_url)
     end
 
     context "when filtering by site ids" do
@@ -63,7 +63,7 @@ RSpec.describe "Sites" do
 
         csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
         expect(csv.count).to eq(1)
-        expect(csv.first["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
+        expect(csv.first["Adresse du site"]).to eq(other_site.normalized_url)
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe "Sites" do
 
         csv = CSV.parse(csv_without_bom, col_sep: ";", headers: true)
         expect(csv.count).to eq(1)
-        expect(csv.first["Adresse du site"]).to eq(other_site.url_without_scheme_and_www)
+        expect(csv.first["Adresse du site"]).to eq(other_site.normalized_url)
       end
     end
   end
@@ -184,9 +184,9 @@ RSpec.describe "Sites" do
   describe "DELETE /sites" do
     subject(:delete_sites) { delete bulk_destroy_sites_path, params: { id: site_ids } }
 
-    let!(:site) { create(:site, team:) }
-    let!(:other_site) { create(:site, team:) }
-    let!(:team_site) { create(:site, team: create(:team)) }
+    let!(:site) { create(:site, :completed, team:) }
+    let!(:other_site) { create(:site, :completed, team:) }
+    let!(:team_site) { create(:site, :completed, team: create(:team)) }
     let(:site_ids) { [site.id, other_site.id] }
 
     it "destroys selected sites and redirects to index" do

--- a/spec/services/fetch_home_page_service_spec.rb
+++ b/spec/services/fetch_home_page_service_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe FetchHomePageService do
     allow(audit).to receive(:update_home_page!)
   end
 
-  it "calls Browser.get with the audit URL" do
+  it "calls Browser.get with the site URL" do
     fetch!
 
-    expect(Browser).to have_received(:get).with(audit.url)
+    expect(Browser).to have_received(:get).with(audit.site.url)
   end
 
   it "stores the home page on the audit" do


### PR DESCRIPTION
Populate `url` and `normalized_url` in `site` using `audit` `url`.

Side effect : Fix #500 🥳 
