### PR TITLE
feat: Ajouter le widget JDMA

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,7 @@ module ApplicationHelper
   include DsfrHelper
   include PageHelper
   include IconHelper
+  include JdmaHelper
 
   TRUNCATION_LENGTH = 35.freeze
 

--- a/app/helpers/jdma_helper.rb
+++ b/app/helpers/jdma_helper.rb
@@ -1,0 +1,28 @@
+module JdmaHelper
+  JDMA_HOST = "https://jedonnemonavis.numerique.gouv.fr".freeze
+
+  def jdma_widget_config
+    return staging_jdma_widget_config if Rails.application.staging?
+    return production_jdma_widget_config if Rails.env.production?
+
+    nil
+  end
+
+  private
+
+  def staging_jdma_widget_config
+    {
+      form_url: "#{JDMA_HOST}/Demarches/avis/2229?button=4664",
+      button_image: "#{JDMA_HOST}/static/buttons/button-remark-solid-light.svg",
+      button_label: t("jdma.staging_button_label"),
+    }
+  end
+
+  def production_jdma_widget_config
+    {
+      form_url: "#{JDMA_HOST}/Demarches/avis/2230?button=4666",
+      button_image: "#{JDMA_HOST}/static/buttons/button-problem-solid-light.svg",
+      button_label: t("jdma.production_button_label"),
+    }
+  end
+end

--- a/app/helpers/jdma_helper.rb
+++ b/app/helpers/jdma_helper.rb
@@ -1,23 +1,25 @@
 module JdmaHelper
   JDMA_HOST = "https://jedonnemonavis.numerique.gouv.fr".freeze
-  JDMA_STAGING_FORM_ID = "2229".freeze
-  JDMA_PRODUCTION_FORM_ID = "2230".freeze
-  JDMA_BUTTON_ID = "4675".freeze
+  JDMA_STAGING_FORM_URL = "#{JDMA_HOST}/Demarches/avis/2229?button=4675".freeze
+  JDMA_PRODUCTION_FORM_URL = "#{JDMA_HOST}/Demarches/avis/2230?button=4675".freeze
   JDMA_BUTTON_IMAGE = "#{JDMA_HOST}/static/buttons/button-problem-ghost-light.svg".freeze
 
   def jdma_widget_config
-    form_id = if Rails.application.staging?
-      JDMA_STAGING_FORM_ID
-    elsif Rails.env.production?
-      JDMA_PRODUCTION_FORM_ID
-    end
-
-    return if form_id.nil?
+    return unless jdma_form_url
 
     {
-      form_url: "#{JDMA_HOST}/Demarches/avis/#{form_id}?button=#{JDMA_BUTTON_ID}",
+      form_url: jdma_form_url,
       button_image: JDMA_BUTTON_IMAGE,
       button_label: t("jdma.button_label"),
     }
+  end
+
+  private
+
+  def jdma_form_url
+    return JDMA_STAGING_FORM_URL if Rails.application.staging?
+    return JDMA_PRODUCTION_FORM_URL if Rails.env.production?
+
+    nil
   end
 end

--- a/app/helpers/jdma_helper.rb
+++ b/app/helpers/jdma_helper.rb
@@ -1,28 +1,23 @@
 module JdmaHelper
   JDMA_HOST = "https://jedonnemonavis.numerique.gouv.fr".freeze
+  JDMA_STAGING_FORM_ID = "2229".freeze
+  JDMA_PRODUCTION_FORM_ID = "2230".freeze
+  JDMA_BUTTON_ID = "4675".freeze
+  JDMA_BUTTON_IMAGE = "#{JDMA_HOST}/static/buttons/button-problem-ghost-light.svg".freeze
 
   def jdma_widget_config
-    return staging_jdma_widget_config if Rails.application.staging?
-    return production_jdma_widget_config if Rails.env.production?
+    form_id = if Rails.application.staging?
+      JDMA_STAGING_FORM_ID
+    elsif Rails.env.production?
+      JDMA_PRODUCTION_FORM_ID
+    end
 
-    nil
-  end
+    return if form_id.nil?
 
-  private
-
-  def staging_jdma_widget_config
     {
-      form_url: "#{JDMA_HOST}/Demarches/avis/2229?button=4664",
-      button_image: "#{JDMA_HOST}/static/buttons/button-remark-solid-light.svg",
-      button_label: t("jdma.staging_button_label"),
-    }
-  end
-
-  def production_jdma_widget_config
-    {
-      form_url: "#{JDMA_HOST}/Demarches/avis/2230?button=4666",
-      button_image: "#{JDMA_HOST}/static/buttons/button-problem-solid-light.svg",
-      button_label: t("jdma.production_button_label"),
+      form_url: "#{JDMA_HOST}/Demarches/avis/#{form_id}?button=#{JDMA_BUTTON_ID}",
+      button_image: JDMA_BUTTON_IMAGE,
+      button_label: t("jdma.button_label"),
     }
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,5 +53,6 @@
 
 <%= render "shared/footer" %>
 <%= turbo_frame_tag :modal %>
+<%= render "shared/jdma_widget" %>
 </body>
 </html>

--- a/app/views/shared/_jdma_widget.html.erb
+++ b/app/views/shared/_jdma_widget.html.erb
@@ -1,4 +1,7 @@
-<% if (config = jdma_widget_config) %>
+<% config = jdma_widget_config %>
+<% show_jdma_widget = authenticated? && config.present? %>
+
+<% if show_jdma_widget %>
   <%= javascript_include_tag(
         "#{JdmaHelper::JDMA_HOST}/static/jdma-modal-widget.js",
         nonce: true,

--- a/app/views/shared/_jdma_widget.html.erb
+++ b/app/views/shared/_jdma_widget.html.erb
@@ -1,0 +1,13 @@
+<% if (config = jdma_widget_config) %>
+  <%= javascript_include_tag(
+        "#{JdmaHelper::JDMA_HOST}/static/jdma-modal-widget.js",
+        nonce: true,
+        defer: true,
+        data: {
+          jdma_form_url: config[:form_url],
+          jdma_button_image: config[:button_image],
+          jdma_button_label: config[:button_label],
+          jdma_position: "bottom-right",
+        }
+      ) %>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,14 +4,17 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
+JDMA_HOST = "https://jedonnemonavis.numerique.gouv.fr".freeze
+
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.font_src    :self
-    policy.img_src     :self, :data
+    policy.img_src     :self, :data, JDMA_HOST
     policy.object_src  :none
     policy.script_src  :self
     policy.style_src   :self
+    policy.frame_src   JDMA_HOST
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -167,6 +167,9 @@ fr:
     service_description: "Contrôle l'accessibilité et la conformité des sites internet"
     service_name: "Accès cible (version beta)"
     sponsor_html: "Gouvernement"
+  jdma:
+    production_button_label: Signaler un problème
+    staging_button_label: Une remarque ?
   pages:
     accessibilite:
       title: Déclaration d’accessibilité

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -168,8 +168,7 @@ fr:
     service_name: "Accès cible (version beta)"
     sponsor_html: "Gouvernement"
   jdma:
-    production_button_label: Signaler un problème
-    staging_button_label: Une remarque ?
+    button_label: Signaler un problème
   pages:
     accessibilite:
       title: Déclaration d’accessibilité

--- a/spec/helpers/jdma_helper_spec.rb
+++ b/spec/helpers/jdma_helper_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe JdmaHelper do
 
       it "uses the staging widget configuration" do
         expect(config).to eq(
-          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2229?button=4664",
-          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-remark-solid-light.svg",
-          button_label: "Une remarque ?",
+          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2229?button=4675",
+          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-problem-ghost-light.svg",
+          button_label: "Signaler un problème",
         )
       end
     end
@@ -27,8 +27,8 @@ RSpec.describe JdmaHelper do
 
       it "uses the production widget configuration" do
         expect(config).to eq(
-          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2230?button=4666",
-          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-problem-solid-light.svg",
+          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2230?button=4675",
+          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-problem-ghost-light.svg",
           button_label: "Signaler un problème",
         )
       end

--- a/spec/helpers/jdma_helper_spec.rb
+++ b/spec/helpers/jdma_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe JdmaHelper do
         expect(config).to eq(
           form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2229?button=4664",
           button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-remark-solid-light.svg",
-          button_label: I18n.t("jdma.staging_button_label"),
+          button_label: "Une remarque ?",
         )
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe JdmaHelper do
         expect(config).to eq(
           form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2230?button=4666",
           button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-problem-solid-light.svg",
-          button_label: I18n.t("jdma.production_button_label"),
+          button_label: "Signaler un problème",
         )
       end
     end

--- a/spec/helpers/jdma_helper_spec.rb
+++ b/spec/helpers/jdma_helper_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe JdmaHelper do
+  describe "#jdma_widget_config" do
+    subject(:config) { helper.jdma_widget_config }
+
+    context "when running in staging" do
+      before do
+        allow(Rails.application).to receive(:staging?).and_return(true)
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "uses the staging widget configuration" do
+        expect(config).to eq(
+          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2229?button=4664",
+          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-remark-solid-light.svg",
+          button_label: I18n.t("jdma.staging_button_label"),
+        )
+      end
+    end
+
+    context "when running in production" do
+      before do
+        allow(Rails.application).to receive(:staging?).and_return(false)
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "uses the production widget configuration" do
+        expect(config).to eq(
+          form_url: "https://jedonnemonavis.numerique.gouv.fr/Demarches/avis/2230?button=4666",
+          button_image: "https://jedonnemonavis.numerique.gouv.fr/static/buttons/button-problem-solid-light.svg",
+          button_label: I18n.t("jdma.production_button_label"),
+        )
+      end
+    end
+
+    context "when running outside deployed environments" do
+      before do
+        allow(Rails.application).to receive(:staging?).and_return(false)
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+
+      it "does not enable the widget" do
+        expect(config).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/jdma_widget_spec.rb
+++ b/spec/requests/jdma_widget_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "JDMA widget" do
+  let(:user) { create(:user) }
+
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+  end
+
+  it "is hidden from unauthenticated users" do
+    get root_path
+
+    expect(response.body).not_to include("jdma-modal-widget.js")
+  end
+
+  it "is shown to authenticated users" do
+    login_as(user)
+
+    get root_path
+
+    expect(response.body).to include("jdma-modal-widget.js")
+  end
+end


### PR DESCRIPTION
## Changements

Ajout du widget Je donne mon avis sur staging et production, afin de recolter les avis des utilisateurs.

## A savoir 

- Je n'ai pas géré la couleur du bouton en dark-mode, car l'info de light ou dark est stocké coté client. Il faudrait donc surcharger le script pour afficher une image de bouton light ou dark. On ne pourrait plus utiliser aussi javascript_include_tag qui est une manière plus sécurisé et propre je trouve de mettre un script, qu'un simple <script>...
Je ne suis pas fermé pour changer si on décide qu'on préfère surcharger le script ou de mettre le <script> qui était fourni dans le ticket. 
A savoir aussi que le light ou dark mode n'a pas l'air d'être géré dans la modal de JDMA, et je n'ai pas accès a la documentation.

- J'ai laissé les url dans le Helper, car c'est une url publique dans le frontend quand on inspecte la page avec le navigateur. Je suis aussi ouvert a la discussion si on préfère les mettre dans des crédentials

## Screenshot
<img width="261" height="109" alt="Capture d’écran 2026-05-19 à 14 40 41" src="https://github.com/user-attachments/assets/0fcfbbd5-85cd-4fb6-85fb-408a89f93697" />
<img width="255" height="116" alt="Capture d’écran 2026-05-19 à 14 40 30" src="https://github.com/user-attachments/assets/e813370d-4044-4892-b762-7eda144d2f89" />
