### PR TITLE
fix: Site.url est maintenant normalizé

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -19,6 +19,7 @@ class Site < ApplicationRecord
   friendly_id :normalized_url, use: [:slugged, :history, :scoped], scope: :team_id
 
   validates :url, presence: true, url: true
+  normalizes :url, with: ->(url) { Link.normalize(url) }
 
   broadcasts_refreshes
 

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Checks::Reachable do
   let(:check) { described_class.new }
-  let(:original_url) { "https://example.com" }
+  let(:original_url) { "https://example.com/" }
   let(:home_page_url) { original_url }
   let(:root_page) { instance_double(Page, html: nil) }
   let(:site) { create(:site, url: original_url) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Site do
 
   it { is_expected.to be_valid }
 
+  it "normalizes its URL" do
+    site = create(:site, url: " HTTPS://EXAMPLE.COM/path/ ")
+
+    expect(site.url).to eq("https://example.com/path/")
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:team).touch(true) }
     it { is_expected.to have_many(:audits).dependent(:destroy) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Site do
 
   it { is_expected.to be_valid }
 
-  it "normalizes its URL" do
-    site = create(:site, url: " HTTPS://EXAMPLE.COM/path/ ")
+  describe "URL normalization" do
+    subject(:site) { create(:site, url: " HTTPS://EXAMPLE.COM/path/ ") }
 
-    expect(site.url).to eq("https://example.com/path/")
+    it "normalizes its URL" do
+      site = create(:site, url: " HTTPS://EXAMPLE.COM/path/ ")
+
+      expect(site.url).to eq("https://example.com/path/")
+    end
   end
 
   describe "associations" do


### PR DESCRIPTION
Fix cette erreur : https://sentry.incubateur.net/organizations/betagouv/issues/281824/?environment=staging&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

Site.url n'etait pas normalizé, donc on pouvait enregistrer des espaces dans l'URL.
Je pense que `Link.normalize` est la fonction existante qui est parfaite pour ce use_case

Je ne suis pas sur qu'il y ai besoin de backfill de la data, je pense que le bug est que en staging pour le moment mais je peux verifier