### PR TITLE
bug: éviter les doublons de tags lors de l’import CSV

### DIFF
--- a/app/services/site_batch_creation_service.rb
+++ b/app/services/site_batch_creation_service.rb
@@ -6,6 +6,7 @@ class SiteBatchCreationService
 
   def process(site_data)
     site_tag_ids = @tag_ids + tag_ids_from_names(site_data["tag_names"] || [])
+    site_tag_ids = normalized_tag_ids(site_tag_ids)
     site = @team.sites.find_by(url: site_data["url"])
 
     if site
@@ -22,6 +23,10 @@ class SiteBatchCreationService
     site.tag_ids = site_tag_ids.union(site.tag_ids)
     site.name = site_data["name"] if site_data["name"].present? && site.name.blank?
     site.save!
+  end
+
+  def normalized_tag_ids(tag_ids)
+    tag_ids.compact_blank.map(&:to_i).uniq
   end
 
   def tag_ids_from_names(tag_names)

--- a/app/services/site_batch_creation_service.rb
+++ b/app/services/site_batch_creation_service.rb
@@ -5,15 +5,14 @@ class SiteBatchCreationService
   end
 
   def process(site_data)
-    site_tag_ids = @tag_ids + tag_ids_from_names(site_data["tag_names"] || [])
-    site_tag_ids = normalized_tag_ids(site_tag_ids)
+    tag_ids = site_tag_ids(site_data)
     site = @team.sites.find_by(url: site_data["url"])
 
     if site
-      update_site(site, site_data, site_tag_ids)
+      update_site(site, site_data, tag_ids)
       site.audit!
     else
-      Site.create!(url: site_data["url"], team: @team, name: site_data["name"], tag_ids: site_tag_ids.uniq).audit!
+      Site.create!(url: site_data["url"], team: @team, name: site_data["name"], tag_ids:).audit!
     end
   end
 
@@ -25,7 +24,8 @@ class SiteBatchCreationService
     site.save!
   end
 
-  def normalized_tag_ids(tag_ids)
+  def site_tag_ids(site_data)
+    tag_ids = @tag_ids + tag_ids_from_names(site_data["tag_names"] || [])
     tag_ids.compact_blank.map(&:to_i).uniq
   end
 

--- a/spec/services/site_batch_creation_service_spec.rb
+++ b/spec/services/site_batch_creation_service_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe SiteBatchCreationService do
           expect { process_site }.not_to change { existing_site.reload.name }
         end
       end
+
+      context "when a selected tag is already attached and present in the CSV" do
+        let(:site_data) { { "url" => url, "tag_names" => ["existing_tag"] } }
+        let(:extra_tag_ids) { [existing_tag.id.to_s] }
+
+        it "does not try to attach the same tag twice" do
+          process_site
+
+          expect(existing_site.reload.tags.map(&:name)).to contain_exactly("existing_tag")
+        end
+      end
     end
 
     context "with duplicate tags" do
@@ -110,6 +121,16 @@ RSpec.describe SiteBatchCreationService do
         process_site
 
         expect(site_tags).to contain_exactly("tag")
+      end
+
+      context "when selected tag IDs include a blank value from the form" do
+        let(:extra_tag_ids) { [""] }
+
+        it "ignores blank tag IDs" do
+          process_site
+
+          expect(site_tags).to contain_exactly("tag")
+        end
       end
     end
   end


### PR DESCRIPTION
Quand on importe une liste de sites avec un tag, si un tag déjà existant était à la fois sélectionné dans le formulaire et présent dans la colonne `tags` du CSV, l’import échouait avec l'erreur : 
`ActiveRecord::RecordNotUnique
New
Level: Error
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_site_tags_on_site_id_and_tag_id"
`

Le problème venait du fait que les IDs des tags sélectionnés arrivaient depuis les paramètres sous forme de string (`"62"`), tandis que les IDs des tags retrouvés depuis le CSV étaient des entiers (`62`). La déduplication ne les considérait donc pas comme identiques, ce qui pouvait provoquer une tentative d’insertion en double dans `site_tags` et on avait l'erreur
