### PR TITLE
chore: Remove `current` column from `audits` table

### DIFF
--- a/db/migrate/20260601082116_remove_current_from_audits.rb
+++ b/db/migrate/20260601082116_remove_current_from_audits.rb
@@ -1,0 +1,17 @@
+class RemoveCurrentFromAudits < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :audits, :current, :boolean
+  end
+
+  def down
+    add_column :audits, :current, :boolean, default: false, null: false
+
+    Site.find_in_batches do |sites|
+      sites.each do |site|
+        current_audit = site.audits.where(completed_at: site.last_audited_at).first
+        next if current_audit.blank?
+        current_audit.update_column(:current, true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_21_085429) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_082116) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,14 +19,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_085429) do
     t.string "accessibility_page_url"
     t.datetime "completed_at"
     t.datetime "created_at", null: false
-    t.boolean "current", default: false, null: false
     t.text "home_page_html"
     t.string "home_page_url"
     t.bigint "site_id", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
     t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
-    t.index ["site_id", "current"], name: "index_audits_on_site_id_and_current", unique: true, where: "(current = true)"
     t.index ["site_id"], name: "index_audits_on_site_id"
     t.index ["url"], name: "index_audits_on_url"
   end


### PR DESCRIPTION
- Drop unused `current` column and associated index.
- Add reversible migration logic to restore data if needed.