### PR TITLE
chore: Remove `url` column from `audits` table

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -4,9 +4,6 @@ class Audit < ApplicationRecord
 
   after_create_commit :fetch_resources!, :create_checks
 
-  validates :url, presence: true, url: true
-  normalizes :url, with: ->(url) { Link.normalize(url).to_s }
-
   scope :sort_by_newest, -> { order(created_at: :desc) }
   scope :completed, -> { where.not(completed_at: nil) }
   scope :with_check_transitions, -> { includes(checks: :check_transitions) }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -18,6 +18,7 @@ class Site < ApplicationRecord
 
   friendly_id :normalized_url, use: [:slugged, :history, :scoped], scope: :team_id
 
+  validates :normalized_url, presence: true
   validates :url, presence: true, url: true
   normalizes :url, with: ->(url) { Link.normalize(url) }
 
@@ -45,7 +46,7 @@ class Site < ApplicationRecord
   end
 
   def audit!
-    audits.create!(url:)
+    audits.create!
   end
 
   def tags_list

--- a/db/migrate/20260601092126_remove_url_from_audits.rb
+++ b/db/migrate/20260601092126_remove_url_from_audits.rb
@@ -1,0 +1,8 @@
+class RemoveUrlFromAudits < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :audits, :url, :string
+
+    change_column_null :sites, :url, false
+    change_column_null :sites, :normalized_url, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_082116) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_092126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,10 +23,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082116) do
     t.string "home_page_url"
     t.bigint "site_id", null: false
     t.datetime "updated_at", null: false
-    t.string "url", null: false
-    t.index "regexp_replace((url)::text, '^https?://(www.)?'::text, ''::text)", name: "index_audits_on_normalized_url"
     t.index ["site_id"], name: "index_audits_on_site_id"
-    t.index ["url"], name: "index_audits_on_url"
   end
 
   create_table "check_transitions", force: :cascade do |t|
@@ -82,12 +79,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082116) do
     t.datetime "created_at", null: false
     t.datetime "last_audited_at"
     t.string "name"
-    t.string "normalized_url"
+    t.string "normalized_url", null: false
     t.string "slug", null: false
     t.integer "tags_count", default: 0, null: false
     t.bigint "team_id", null: false
     t.datetime "updated_at", null: false
-    t.string "url"
+    t.string "url", null: false
     t.index ["slug", "team_id"], name: "index_sites_on_slug_and_team_id", unique: true
     t.index ["team_id"], name: "index_sites_on_team_id"
   end

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :audit do
-    url { "https://example.com" }
-    site { association :site, url:, audits: [instance] }
+    site { association :site, audits: [instance] }
 
     trait :without_checks do
       after(:create) do |audit, _eval|

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :site do
     sequence(:url) { |n| "https://www.example-#{n}.com/" }
+    sequence(:normalized_url) { |n| "example-#{n}.com" }
     team { association :team }
     audits { [association(:audit)] }
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -12,18 +12,6 @@ RSpec.describe Audit do
     it { is_expected.to have_many(:checks).dependent(:destroy) }
   end
 
-  describe "validations" do
-    it { is_expected.to allow_value("https://example.com").for(:url) }
-    it { is_expected.not_to allow_value("not-a-url").for(:url) }
-  end
-
-  describe "normalization" do
-    it "normalizes URLs" do
-      audit.url = "HTTPS://EXAMPLE.COM/path/"
-      expect(audit.url).to eq("https://example.com/path/")
-    end
-  end
-
   describe "scopes" do
     before { site.audits.destroy_all }
 

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sites" do
 
     context "when an audit has not created its checks yet" do
       let!(:site) { create(:site, team:) }
-      let!(:audit) { create(:audit, :without_checks, site:, url: site.url) }
+      let!(:audit) { create(:audit, :without_checks, site:) }
 
       it "renders a pending badge for every expected check" do
         get_sites

--- a/spec/services/find_accessibility_page_service_spec.rb
+++ b/spec/services/find_accessibility_page_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe FindAccessibilityPageService do
 
   let(:root_url) { "https://example.com" }
   let(:home_page_html) { '<a href="/accessibilite">Accessibilité</a>' }
-  let(:audit) { build(:audit, url: root_url, home_page_url: root_url, home_page_html: home_page_html) }
+  let(:site) { build(:site, url: root_url) }
+  let(:audit) { build(:audit, site:, home_page_url: root_url, home_page_html: home_page_html) }
 
   describe ".call" do
     let(:matching_page_url) { "https://example.com/accessibility" }
@@ -104,7 +105,7 @@ RSpec.describe FindAccessibilityPageService do
   end
 
   describe ".enqueue_children" do
-    let(:audit) { build(:audit, url: "https://example.com", home_page_url: "https://www.example.com/redirection") }
+    let(:audit) { build(:audit, site:, home_page_url: "https://www.example.com/redirection") }
     let(:queue) { LinkList.new }
     let(:page) { instance_double(Page, url: "https://example.com/a") }
     let(:links) do


### PR DESCRIPTION
- Add `normalized_url` validation to `sites`.
- Refactor `audits` to rely on associated `site` for URLs.

