### PR TITLE
RFC: chrome: use a dedicated Chrome instance

### DIFF
--- a/Dockerfile.chrome
+++ b/Dockerfile.chrome
@@ -1,0 +1,9 @@
+FROM debian:trixie-slim
+
+EXPOSE 9222
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install --no-install-recommends -y chromium-headless-shell
+
+CMD ["chromium-headless-shell", "--no-sandbox", "--remote-debugging-port=9222", "--remote-allow-origins=*"]

--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -79,6 +79,7 @@ class Browser
 
     def settings
       {
+        url: ENV.fetch("CHROME_URL"),
         headless: :new,
         timeout: PAGE_TIMEOUT,
         process_timeout: PROCESS_TIMEOUT,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "/app/node_modules"
     depends_on:
       - db
+      - chrome
   css-watcher:
     <<: *server
     command: ["bin/rails", "dartsass:watch"]
@@ -24,12 +25,17 @@ services:
   jobs:
     <<: *server
     command: "bin/jobs"
+    network_mode: service:chrome
     entrypoint: ''
     ports: []
     environment:
       DATABASE_URL: 'postgresql://postgres:dummy@db:5433'
       RUBY_DEBUG_PORT: 3500
       RUBY_DEBUG_PORT_RANGE: 10
+      CHROME_URL: http://localhost:9222 # funnily enough only the workers need it
+    depends_on:
+      - db
+      - chrome
   db:
     image: postgres:16
     environment:
@@ -39,3 +45,8 @@ services:
       - "./tmp/db:/var/lib/postgresql/data"
     ports:
       - "5433:5433"
+  chrome:
+    build:
+      dockerfile: Dockerfile.chrome
+    ports:
+      - "9222:9222"


### PR DESCRIPTION
Du commit: 

> We've had a long time problem on this project: the complete darkness surrounding the crawling done by Chrome within our processes. That's because we don't provide a browser URL to Ferrum, and so Ferrum boots its own Chrome process within its Ruby process[1].
> 
> This means we're unable to correctly debug our jobs containers on Scalingo (we can't SH into our running containers, we cannot run `ps` on them), and that these containers inevitably grow very large because on top of their own overhead (our Ruby/Rails app) they have to allocate and run their own Chrome process which adds a fair amount of memory and CPU to their own.
> 
> Demonstrate a new approach here where we run Chrome separately, on a new Docker container we control (on Scalingo we can use a buildpack instead[2]) and then we just feed to Ferrum our local URL.
> 
> This allows us to log, inspect and monitor our Chrome business while keeping our Ruby job containers happy & safe, away from the nightmarish world of web browsers.
> 
> [1]: https://github.com/rubycdp/ferrum/blob/9fae889c724ab4388bee2c5f54a440e0e095b86a/lib/ferrum/browser.rb#L114-L116
> [2]: https://github.com/betterplace/scalingo-buildpack-google-chrome