### PR TITLE
gem: remove my custom Omniauth fork

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ ENV WITHIN_DOCKER=1
 
 EXPOSE 3000
 
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y build-essential libpq-dev libyaml-dev chromium git
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y build-essential libpq-dev libyaml-dev chromium
 
 # do the bundle install in another directory with the strict essential
 # (Gemfile and Gemfile.lock) to allow further steps to be cached

--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,7 @@ gem "dsfr-view-components"
 gem "friendly_id"
 
 # Manage external authentication
-# FIXME: until https://github.com/omniauth/omniauth/pull/1146
-gem "omniauth", github: "freesteph/omniauth", branch: "fix/dont-call-setup-phase-in-test-mode"
+gem "omniauth"
 gem "omniauth-proconnect"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/freesteph/omniauth.git
-  revision: 6ecc52c674e02c84adba3e9b23e1b12c8b435a6d
-  branch: fix/dont-call-setup-phase-in-test-mode
-  specs:
-    omniauth (2.1.3)
-      hashie (>= 3.4.6)
-      logger
-      rack (>= 2.2.3)
-      rack-protection
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -190,13 +179,13 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ferrum (0.17.2)
       addressable (~> 2.5)
@@ -296,8 +285,8 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.5)
-    json-jwt (1.17.0)
+    json (2.19.8)
+    json-jwt (1.17.1)
       activesupport (>= 4.2)
       aes_key_wrap
       base64
@@ -380,7 +369,12 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    omniauth-proconnect (0.5)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-proconnect (0.6)
       faraday (~> 2)
       json-jwt (~> 1)
       omniauth
@@ -679,7 +673,7 @@ DEPENDENCIES
   markdown_views
   memory_profiler
   mission_control-jobs (~> 1.1)
-  omniauth!
+  omniauth
   omniauth-proconnect
   omniauth-rails_csrf_protection
   pagy (~> 43)


### PR DESCRIPTION
I've removed my faulty `setup_phase!` in omniauth-proconnect[1] so there is no need to use a custom fork anymore.

[1]: https://github.com/betagouv/omniauth-proconnect/pull/7