### PR TITLE
chore: add jemalloc buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/studoverse/scalingo-buildpack-google-chrome
+https://github.com/Scalingo/jemalloc-buildpack.git
 https://github.com/Scalingo/ruby-buildpack.git


### PR DESCRIPTION
Test sur staging avec 5000 :
<img width="1560" height="860" alt="Capture d’écran 2026-06-11 à 14 09 27" src="https://github.com/user-attachments/assets/e179a683-11d4-453d-982a-83a69f3ccf3a" />
Après deploiement, ne pas oublier de lancer la commande pour ajouter la variable d'environnement pour activer Jemalloc : `scalingo env-set JEMALLOC_ENABLED=true`