### PR TITLE
fix: Don't load HTML snapshots

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -29,7 +29,7 @@ class SitesController < ApplicationController
 
   # GET /sites/1
   def show
-    @audit = @site.last_audit
+    @audit = @site.last_audit_without_html
   end
 
   # GET /sites/new

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -38,7 +38,7 @@ class SiteCsvExport
 
     sites.in_batches(of: 200) do |batch|
       batch.preloaded.each do |site|
-        audit = site.last_audit
+        audit = site.last_audit_without_html
 
         reachable = audit&.reachable
         language = audit&.language_indication

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -7,6 +7,7 @@ class Audit < ApplicationRecord
   scope :sort_by_newest, -> { order(created_at: :desc) }
   scope :completed, -> { where.not(completed_at: nil) }
   scope :with_check_transitions, -> { includes(checks: :check_transitions) }
+  scope :without_html, -> { select(column_names - %w[home_page_html accessibility_page_html]) }
 
   Check.types.each do |name, klass|
     define_method(name) do

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -5,14 +5,15 @@ class Site < ApplicationRecord
 
   has_many :audits, -> { sort_by_newest }, dependent: :destroy
 
-  has_one :last_audit, -> { order(created_at: :desc).without_html }, class_name: "Audit"
+  has_one :last_audit_without_html, -> { order(created_at: :desc).without_html }, class_name: "Audit"
+  has_one :last_audit, -> { order(created_at: :desc) }, class_name: "Audit"
 
   has_many :site_tags, dependent: :destroy
   has_many :tags, -> { in_alphabetical_order }, through: :site_tags
 
   accepts_nested_attributes_for :tags, reject_if: :all_blank
 
-  scope :preloaded, -> { preload(:tags, :slugs, last_audit: { checks: :check_transitions }) }
+  scope :preloaded, -> { preload(:tags, :slugs, last_audit_without_html: { checks: :check_transitions }) }
 
   before_validation :set_normalized_url, if: :will_save_change_to_url?
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -5,7 +5,7 @@ class Site < ApplicationRecord
 
   has_many :audits, -> { sort_by_newest }, dependent: :destroy
 
-  has_one :last_audit, -> { order(created_at: :desc) }, class_name: "Audit"
+  has_one :last_audit, -> { order(created_at: :desc).without_html }, class_name: "Audit"
 
   has_many :site_tags, dependent: :destroy
   has_many :tags, -> { in_alphabetical_order }, through: :site_tags

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,4 +1,4 @@
-<% last_audit = site.last_audit %>
+<% last_audit = site.last_audit_without_html %>
 
 <tr id="<%= dom_id(site, :sites_table) %>">
   <%= dsfr_row_check(site) %>


### PR DESCRIPTION
Add without_html scope to Audit and use it for last_audit in `Site`

- Introduce `without_html` scope to exclude HTML fields from selection.
- Update `last_audit` association in `Site` to use the new scope.

✅ Tested and ~approved in staging.
Still have performance issues but this is getting better 