### PR TITLE
chore: block chrome cookies in order to dont use browser service worker

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -1,3 +1,6 @@
+require "fileutils"
+require "json"
+
 class Browser
   PAGE_TIMEOUT = 1.minute
   PROCESS_TIMEOUT = 30.seconds
@@ -43,6 +46,17 @@ class Browser
     "disable-features" => "TranslateUI,VizDisplayCompositor",
     "disable-gpu" => nil,
     "no-sandbox" => nil
+  }.freeze
+
+  CHROME_CONTENT_SETTING_BLOCK = 2
+
+  CHROME_PROFILE_PREFERENCES = {
+    profile: {
+      block_third_party_cookies: true,
+      default_content_setting_values: {
+        cookies: CHROME_CONTENT_SETTING_BLOCK
+      }
+    }
   }.freeze
 
   STEALTH_EXTENSION = Rails.root.join("vendor/javascript/stealth.min.js").freeze
@@ -128,6 +142,8 @@ class Browser
     private
 
     def browser
+      prepare_user_data_dir
+
       @browser ||= Ferrum::Browser.new(settings)
     end
 
@@ -139,6 +155,13 @@ class Browser
 
     def user_data_dir
       @user_data_dir ||= "/tmp/chrome-#{SecureRandom.hex(8)}"
+    end
+
+    def prepare_user_data_dir
+      preferences_path = File.join(user_data_dir, "Default", "Preferences")
+
+      FileUtils.mkdir_p(File.dirname(preferences_path))
+      File.write(preferences_path, JSON.generate(CHROME_PROFILE_PREFERENCES))
     end
 
     def with_page


### PR DESCRIPTION
la seule solution que j'ai trouvé et qui fonctionne aujourd'hui pour ne pas que les service worker fonctionnent est de bloquer les cookies dans les parametre Chromium.

J'ai testé sur des url comme [toutry.fr](http://www.toutry.fr/), [semarey.fr](http://www.semarey.fr/), [saints-en-puisaye.fr](http://www.saints-en-puisaye.fr/), [usseldallier.fr](http://www.usseldallier.fr/) qui utilisent des service worker et en effet ils ne sont pas lancés.

Je ne peux pas confirmer de différence de performance a ce stade