### PR TITLE
feat: Add custom `User-Agent` header

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -4,7 +4,8 @@ class Browser
   SUCCESS_CODE = 200
 
   REQUEST_HEADERS = {
-    "Accept-Language" => "fr"
+    "Accept-Language" => "fr",
+    "User-Agent" => "AccesCible/1.0 (+https://acces-cible.beta.gouv.fr/)"
   }.freeze
 
   BLOCKED_FILE_EXTENSIONS = %w[


### PR DESCRIPTION
[ADICO_HTTP_429.csv](https://github.com/user-attachments/files/29258097/ADICO_HTTP_429.csv)
- Set `User-Agent` to `AccesCible/1.0 (+https://acces-cible.beta.gouv.fr/)` to officially identify AC