### PR TITLE
chore: Ne plus charger les iframe

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -152,8 +152,31 @@ class Browser
     def create_page
       browser.create_page.tap do |page|
         page.headers.set(request_headers)
-        page.network.blocklist = BLOCKED_URL_PATTERNS
+        block_unwanted_requests(page)
       end
+    end
+
+    def block_unwanted_requests(page)
+      page.network.intercept(handle_auth_requests: false)
+      page.on(:request) do |request|
+        if blocked_request?(page, request)
+          request.abort
+        else
+          request.continue
+        end
+      end
+    end
+
+    def blocked_request?(page, request)
+      blocked_url?(request.url) || iframe_document_request?(page, request)
+    end
+
+    def blocked_url?(url)
+      BLOCKED_URL_PATTERNS.any? { |pattern| url.to_s.match?(pattern) }
+    end
+
+    def iframe_document_request?(page, request)
+      request.resource_type == "Document" && request.frame_id != page.main_frame.id
     end
   end
 end


### PR DESCRIPTION
Ce changement bloque les iframe 
Le resultat est positif sur des sites qui ont des iframe comme : http://fontenelle.fr/
Les iframe sont bien bloqué. Et le scraping prend moins d'une seconde au lieu de 30+ secondes
A tester sur main puis cette branche pour voir la différence