### PR TITLE
fix: content type nil error

### DIFF
--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -134,7 +134,7 @@ class Browser
         {
           body: page.body,
           status: page.network.status,
-          content_type: page.network.response.content_type,
+          content_type: page.evaluate("document.contentType"),
           current_url: Link.normalize(page.current_url)
         }
       end

--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -114,7 +114,7 @@ class Browser
         headless: :new,
         timeout: PAGE_TIMEOUT,
         process_timeout: PROCESS_TIMEOUT,
-        pending_connection_errors: true,
+        pending_connection_errors: false,
         extensions: [STEALTH_EXTENSION],
         browser_options: browser_options
       }.tap do |options|

--- a/app/models/browser.rb
+++ b/app/models/browser.rb
@@ -114,7 +114,7 @@ class Browser
         headless: :new,
         timeout: PAGE_TIMEOUT,
         process_timeout: PROCESS_TIMEOUT,
-        pending_connection_errors: false,
+        pending_connection_errors: true,
         extensions: [STEALTH_EXTENSION],
         browser_options: browser_options
       }.tap do |options|

--- a/spec/models/browser_spec.rb
+++ b/spec/models/browser_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe Browser do
     let(:headers_double) { instance_double(Ferrum::Headers) }
     let(:network_double) { instance_double(Ferrum::Network) }
     let(:page_double) { instance_double(Ferrum::Page) }
-    let(:response_double) { instance_double(Ferrum::Network::Response) }
 
     before do
       allow(described_class).to receive(:browser).and_return(browser_double)
@@ -157,9 +156,9 @@ RSpec.describe Browser do
       allow(headers_double).to receive(:set)
       allow(network_double).to receive(:blocklist=)
       allow(network_double).to receive(:wait_for_idle)
-      allow(network_double).to receive_messages(status: 200, response: response_double)
-      allow(response_double).to receive(:content_type).and_return("text/html")
+      allow(network_double).to receive(:status).and_return(200)
       allow(page_double).to receive(:go_to).with(url)
+      allow(page_double).to receive(:evaluate).with("document.contentType").and_return("text/html")
       allow(page_double).to receive_messages(headers: headers_double, network: network_double, body: "<html><body>Test</body></html>", current_url: url)
       allow(page_double).to receive(:close)
       allow(Link).to receive(:normalize).with(url).and_return(url)
@@ -187,6 +186,10 @@ RSpec.describe Browser do
 
     it "returns correct status code" do
       expect(get_result[:status]).to eq(200)
+    end
+
+    it "returns the document content type" do
+      expect(get_result[:content_type]).to eq("text/html")
     end
 
     it "returns normalized current URL" do


### PR DESCRIPTION
Deux problèmes détecté et corrigés pour cette erreur :
- Les erreurs Ferrum lors du timeout étaient desactivés, alors qu'on devrait mettre une erreur et la catch
- Certains sites refont des requetes après que le site est idle, et `page.network.response` est nil
