### PR TITLE
feat: Remove `name` column from `sites`

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -14,7 +14,7 @@ class AuditsController < ApplicationController
   # GET /sites/1/audits/1
   def show
     @audit = @site.audits.with_check_transitions.find(params[:id])
-    @title = @site.to_title
+    @title = @site.normalized_url
 
     render "sites/show"
   end

--- a/app/controllers/concerns/sites_filtering.rb
+++ b/app/controllers/concerns/sites_filtering.rb
@@ -25,7 +25,7 @@ module SitesFiltering
     term = "%#{search_query}%"
 
     scope.where(
-      "sites.name ILIKE ? OR sites.url ILIKE ?",
+      "sites.normalized_url ILIKE ? OR sites.url ILIKE ?",
       term,
       term
     )

--- a/app/export/site_csv_export.rb
+++ b/app/export/site_csv_export.rb
@@ -4,7 +4,6 @@ class SiteCsvExport
 
   HEADERS = [
     I18n.t("audit.site_url_address"),
-    I18n.t("site.name"),
     I18n.t("audit.url"),
     I18n.t("audit.redirect_url"),
     I18n.t("tags.all"),
@@ -52,7 +51,6 @@ class SiteCsvExport
 
         row = [
           site.normalized_url,
-          site.name,
           site.url,
           audit.reachable.redirect_url,
           site.tags_list,

--- a/app/helpers/page_helper.rb
+++ b/app/helpers/page_helper.rb
@@ -4,7 +4,7 @@ module PageHelper
   def page_title
     return @title unless @title.blank?
     return content_for(:title) if content_for?(:title)
-    return resource.to_title if action_name == "show"
+    return resource.to_s if action_name == "show"
 
     action = case action_name.to_sym
     when :create then :new

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -39,8 +39,4 @@ class ApplicationRecord < ActiveRecord::Base
       "#{count} #{model_name.human(count:).downcase}"
     end
   end
-
-  def to_title
-    respond_to?(:name) ? name : to_s
-  end
 end

--- a/app/models/checks/reachable.rb
+++ b/app/models/checks/reachable.rb
@@ -30,8 +30,6 @@ module Checks
     def analyze!
       return unless root_page.success?
 
-      site.update(name: root_page.title) if site && site.name.blank?
-
       if redirected?
         { original_url: site.url, redirect_url: audit.home_page_url }
       else

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -29,12 +29,9 @@ class Site < ApplicationRecord
     self.normalized_url = Link.url_without_scheme_and_www(url)
   end
 
-  def name_with_fallback
-    name.presence || normalized_url
+  def to_s
+    normalized_url
   end
-
-  alias to_title name_with_fallback
-  alias to_s name_with_fallback
 
   def tags_attributes=(attributes)
     return if (name = attributes[:name]).blank?

--- a/app/services/csv_site_parser.rb
+++ b/app/services/csv_site_parser.rb
@@ -63,10 +63,10 @@ class CsvSiteParser
   def report_malformed_csv(error)
     Rails.logger.warn(
       "site_upload_malformed_csv " \
-      "team_id=#{team&.id} " \
-      "filename=#{file&.original_filename} " \
-      "error_class=#{error.class.name} " \
-      "error_message=#{error.message}"
+        "team_id=#{team&.id} " \
+        "filename=#{file&.original_filename} " \
+        "error_class=#{error.class.name} " \
+        "error_message=#{error.message}"
     )
     errors.add(:file, :malformed_csv)
   end
@@ -74,34 +74,27 @@ class CsvSiteParser
   def report_invalid_url(error, raw_url, line_number)
     Rails.logger.warn(
       "site_upload_invalid_url " \
-      "team_id=#{team&.id} " \
-      "filename=#{file&.original_filename} " \
-      "line_number=#{line_number} " \
-      "raw_url=#{raw_url} " \
-      "error_class=#{error.class.name} " \
-      "error_message=#{error.message}"
+        "team_id=#{team&.id} " \
+        "filename=#{file&.original_filename} " \
+        "line_number=#{line_number} " \
+        "raw_url=#{raw_url} " \
+        "error_class=#{error.class.name} " \
+        "error_message=#{error.message}"
     )
     errors.add(:file, :invalid_row_url, line_number:, url: raw_url)
   end
 
   def merge_site_data!(sites_by_url, url, row)
-    name = extract_name(row)
     site_data = sites_by_url[url] || build_site_data(url, row)
     site_data["tag_names"] = (site_data["tag_names"] + extract_tag_names(row)).uniq
-    site_data["name"] = name if name.present?
     sites_by_url[url] = site_data
   end
 
   def build_site_data(url, row)
     {
       "url" => url,
-      "name" => extract_name(row),
       "tag_names" => []
     }
-  end
-
-  def extract_name(row)
-    row["nom"] || row["name"]
   end
 
   def extract_tag_names(row)

--- a/app/services/site_batch_creation_service.rb
+++ b/app/services/site_batch_creation_service.rb
@@ -13,7 +13,7 @@ class SiteBatchCreationService
       update_site(site, site_data, tag_ids)
       site.audit!(user: @user)
     else
-      Site.create!(url: site_data["url"], team: @team, name: site_data["name"], tag_ids:).audit!(user: @user)
+      Site.create!(url: site_data["url"], team: @team, tag_ids:).audit!(user: @user)
     end
   end
 
@@ -21,7 +21,6 @@ class SiteBatchCreationService
 
   def update_site(site, site_data, site_tag_ids)
     site.tag_ids = site_tag_ids.union(site.tag_ids)
-    site.name = site_data["name"] if site_data["name"].present? && site.name.blank?
     site.save!
   end
 

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,9 +1,8 @@
 <%# locals: (site:) %>
 <%= form_with(model: site) do |f| %>
   <%= f.dsfr_input_field :url, :text_field, label: t(".url"), type: :url, required: true, autofocus: true, hint: t('.url_hint') %>
-  <%= f.dsfr_text_field :name, label: t(".name"), hint: t('.name_hint') %>
 
   <%= render "tags_form", object: f.object %>
 
-  <%= f.submit t("shared.#{site.persisted? ? :save : :add}"), name: nil, class: "fr-btn", data: { turbo_submits_with: t("shared.saving") } %>
+  <%= f.submit t("shared.#{site.persisted? ? :save : :add}"), class: "fr-btn", data: { turbo_submits_with: t("shared.saving") } %>
 <% end %>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -2,8 +2,8 @@
 
 <tr id="<%= dom_id(site, :sites_table) %>">
   <%= dsfr_row_check(site) %>
-  <td class="fr-cell--center"><%= link_icon(:article, t('.view_name', name: site.name_with_fallback), url_for([site, last_audit]), title: t('.view_name', name: site.name_with_fallback), line: true, side: :left, sr_only: true) %></td>
   <% display_url = site.normalized_url %>
+  <td class="fr-cell--center"><%= link_icon(:article, t('.view_name', name: display_url), url_for([site, last_audit]), title: t('.view_name', name: display_url), line: true, side: :left, sr_only: true) %></td>
   <% truncated_url = display_url.truncate(ApplicationHelper::TRUNCATION_LENGTH, separator: /\W/) %>
   <% href = Link.safe_external_url(site.url) %>
   <td>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -8,7 +8,7 @@
     <% t.with_body do %>
       <% @sites.each do |site| %>
         <tr>
-          <td><%= dsfr_link_to site.to_s, site %></td>
+          <td><%= dsfr_link_to site.normalized_url, site %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -2,7 +2,7 @@
   <%= dsfr_table(caption: t('tags.all', default: t('sites.index.caption'))) do |t| %>
     <% t.with_head do %>
       <tr>
-        <th scope="col" aria-sort="ascending"><%= t('.name', default: t('site.name')) %></th>
+        <th scope="col" aria-sort="ascending"><%= t('.name') %></th>
       </tr>
     <% end %>
     <% t.with_body do %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -282,8 +282,6 @@ fr:
     edit:
       title: Modifier le site
     form:
-      name: Nom du site
-      name_hint: "Nom utilisé pour l'affichage. S'il est laissé vide, il est récupéré automatiquement lors du prochain audit."
       url: Adresse du site
       url_hint: Saisissez une url valide, commençant par https:// ou http://
     index:

--- a/db/migrate/20260716121525_remove_name_on_sites.rb
+++ b/db/migrate/20260716121525_remove_name_on_sites.rb
@@ -1,0 +1,5 @@
+class RemoveNameOnSites < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :sites, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_124628) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_121525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,7 +80,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_124628) do
     t.integer "audits_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "last_audited_at"
-    t.string "name"
     t.string "normalized_url", null: false
     t.string "slug", null: false
     t.integer "tags_count", default: 0, null: false

--- a/features/ajout_d_un_site.feature
+++ b/features/ajout_d_un_site.feature
@@ -1,6 +1,7 @@
 # language: fr
 
 Fonctionnalité: Ajout d'un site
+
   Contexte:
     Sachant que je suis "marie.curie@gouv.fr" avec le SIRET 123 de l'organisation "DINUM"
     Et que je me pro-connecte
@@ -11,7 +12,6 @@ Fonctionnalité: Ajout d'un site
     Quand je clique sur "Ajouter"
     Alors la page contient "Adresse du site n'est pas valide"
     Quand je remplis "Adresse du site" avec "https://beta.gouv.fr/"
-    Et que je remplis "Nom du site" avec "beta.gouv.fr"
     Quand je clique sur "Ajouter"
     Alors la page contient "Site ajouté"
 

--- a/features/export_csv.feature
+++ b/features/export_csv.feature
@@ -13,7 +13,7 @@ Fonctionnalité: Export d'un CSV
     Quand toutes les tâches de fond sont terminées
     Et que je choisis "Tous les sites" dans le menu principal
     Et que je clique sur "Télécharger en CSV"
-    Alors la page retourne un CSV dont une ligne commence par "foobar.com;Site title;https://foobar.com"
+    Alors la page retourne un CSV dont une ligne commence par "foobar.com;https://foobar.com"
 
   Scénario: je peux exporter uniquement un site sélectionné
     Sachant que je rajoute un site "https://example.com/"

--- a/features/page_du_site.feature
+++ b/features/page_du_site.feature
@@ -9,7 +9,6 @@ Fonctionnalité: Page du site
 
   Scénario: Un agent peut voir les détails d'un site
     Sachant que je remplis "Adresse du site" avec "https://beta.gouv.fr"
-    Et que je remplis "Nom du site" avec "beta.gouv.fr"
     Quand je clique sur "Ajouter"
     Alors la page contient "Site ajouté"
     Et la page contient "https://beta.gouv.fr"
@@ -17,7 +16,6 @@ Fonctionnalité: Page du site
 
   Scénario: Un agent peut demander une nouvelle vérification d'un site
     Sachant que je remplis "Adresse du site" avec "https://beta.gouv.fr"
-    Et que je remplis "Nom du site" avec "beta.gouv.fr"
     Quand je clique sur "Ajouter"
     Et que je clique sur "Nouvelle vérification"
     Alors la page contient "Historique des vérifications (2)"

--- a/spec/export/site_csv_export_spec.rb
+++ b/spec/export/site_csv_export_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe SiteCsvExport do
       it "includes headers" do
         expect(parsed_csv.headers).to eq([
                                            "Adresse du site",
-                                           "Nom du site",
                                            "URL",
                                            "URL de redirection",
                                            "Toutes les étiquettes",
@@ -97,7 +96,6 @@ RSpec.describe SiteCsvExport do
         audit = site.last_audit.reload
 
         expect(row["Adresse du site"]).to eq(site.normalized_url)
-        expect(row["Nom du site"]).to eq(site.name)
         expect(row["URL"]).to eq(site.url)
         expect(row["URL de redirection"]).to be_nil
         expect(row["Toutes les étiquettes"]).to eq(tags.collect(&:name).join(", "))

--- a/spec/models/checks/reachable_spec.rb
+++ b/spec/models/checks/reachable_spec.rb
@@ -41,23 +41,6 @@ RSpec.describe Checks::Reachable do
     end
 
     context "when the site is reachable" do
-      context "when the site has a blank name" do
-        it "updates the site name" do
-          expect(site).to receive(:update).with(name: root_page.title)
-
-          check.send(:analyze!)
-        end
-      end
-
-      context "when the site already has a name" do
-        it "doesn't update site name" do
-          allow(site).to receive(:name).and_return("Site name already set")
-          expect(site).not_to receive(:update)
-
-          check.send(:analyze!)
-        end
-      end
-
       context "when the page does not redirect" do
         let(:home_page_url) { original_url }
 

--- a/spec/models/site_upload_spec.rb
+++ b/spec/models/site_upload_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe SiteUpload do
   let(:tag_ids) { [] }
   let(:parsed_sites_data) do
     [
-      { "url" => "https://example.com/", "name" => "Example Site", "tag_names" => [] },
-      { "url" => "https://test.com/", "name" => "Test Site", "tag_names" => [] }
+      { "url" => "https://example.com/", "tag_names" => [] },
+      { "url" => "https://test.com/", "tag_names" => [] }
     ]
   end
-  let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttps://test.com/,Test Site" }
+  let(:csv_content) { "url\nhttps://example.com/\nhttps://test.com/" }
   let(:encoding) { Encoding::UTF_8 }
   let(:csv) do
     Tempfile.new(["sites", ".csv"], encoding:).tap do |f|
@@ -73,7 +73,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when headers are invalid" do
-      let(:csv_content) { "invalid_header,name\nhttps://example.com/,Example Site" }
+      let(:csv_content) { "invalid_header\nhttps://example.com/" }
 
       it "is invalid" do
         expect(site_upload).not_to be_valid
@@ -82,7 +82,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when headers are uppercase" do
-      let(:csv_content) { "URL,NAME\nhttps://example.com/,Example Site" }
+      let(:csv_content) { "URL\nhttps://example.com/" }
 
       it "ignores case" do
         expect(site_upload).to be_valid
@@ -100,7 +100,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when file uses semicolon separator" do
-      let(:csv_content) { "url;name\nhttps://example.com/;Example Site\nhttps://test.com/;Test Site" }
+      let(:csv_content) { "url;tags\nhttps://example.com/;coucou\nhttps://test.com/" }
 
       it "is valid" do
         expect(site_upload).to be_valid
@@ -108,7 +108,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when file uses semicolon separator with uppercase headers" do
-      let(:csv_content) { "URL;NAME\nhttps://example.com/;Example Site" }
+      let(:csv_content) { "URL;TAGS\nhttps://example.com/;coucou\nhttps://test.com/" }
 
       it "is valid" do
         expect(site_upload).to be_valid
@@ -201,7 +201,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when the CSV is malformed" do
-      let(:csv_content) { %(url,name\n"https://example.com/,Example Site) }
+      let(:csv_content) { %(url\n"https://example.com/) }
 
       it "returns false, adds an error, and logs the parsing failure" do
         allow(Rails.logger).to receive(:warn)
@@ -215,7 +215,7 @@ RSpec.describe SiteUpload do
     end
 
     context "when the CSV contains invalid URLs" do
-      let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttp://,Broken" }
+      let(:csv_content) { "url\nhttps://example.com/\nhttp://" }
 
       before do
         allow(Rails.logger).to receive(:warn)

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Sites" do
   describe "GET /sites/:id" do
     subject(:get_site) { get site_path(site) }
 
-    let(:site) { create(:site, :with_data, team:, name: "Example Site") }
+    let(:site) { create(:site, :with_data, team:) }
 
     it "returns success" do
       get_site
@@ -129,7 +129,7 @@ RSpec.describe "Sites" do
     end
 
     context "when redirected URLs contain HTML" do
-      let(:site) { create(:site, :with_data, team:, name: "Example Site") }
+      let(:site) { create(:site, :with_data, team:) }
       let(:reachable_check) { site.last_audit.reachable }
 
       before do

--- a/spec/services/csv_site_parser_spec.rb
+++ b/spec/services/csv_site_parser_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe CsvSiteParser do
   let(:errors) { ActiveModel::Errors.new(SiteUpload.new) }
   let(:expected_sites_data) do
     [
-      { "url" => "https://example.com/", "name" => "Example Site", "tag_names" => [] },
-      { "url" => "https://test.com/", "name" => "Test Site", "tag_names" => [] }
+      { "url" => "https://example.com/", "tag_names" => [] },
+      { "url" => "https://test.com/", "tag_names" => [] }
     ]
   end
   let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttps://test.com/,Test Site" }
@@ -35,33 +35,25 @@ RSpec.describe CsvSiteParser do
     end
 
     context "with mixed case headers" do
-      let(:csv_content) { "Url,Name\nhttps://example.com/,Example Site" }
+      let(:csv_content) { "Url,\nhttps://example.com/" }
 
       it "ignores header case" do
         expect(parsed_data.first["url"]).to eq("https://example.com/")
-        expect(parsed_data.first["name"]).to eq("Example Site")
       end
     end
 
     context "when file uses semicolon separator" do
       it "parses the CSV file correctly" do
-        csv.write("url;name\nhttps://example.com/;Example Site\nhttps://test.com/;Test Site")
+        csv.write("url;\nhttps://example.com/;\nhttps://test.com/;")
         csv.rewind
 
         expect(parsed_data).to eq(expected_sites_data)
       end
     end
 
-    context "with nom and name columns" do
-      let(:csv_content) { "url,nom,name\nhttps://example.com/,Nom,Name" }
-
-      it "prefers nom over name" do
-        expect(parsed_data.first["name"]).to eq("Nom")
-      end
-    end
 
     context "with tags column" do
-      let(:csv_content) { "url,name,tags\nhttps://example.com/,Example Site,\"tag1, tag2\"" }
+      let(:csv_content) { "url,tags\nhttps://example.com/,\"tag1, tag2\"" }
 
       it "parses tags into an array" do
         expect(parsed_data.first["tag_names"]).to eq(["tag1", "tag2"])
@@ -69,17 +61,16 @@ RSpec.describe CsvSiteParser do
     end
 
     context "with duplicate URLs" do
-      let(:csv_content) { "url,name,tags\nhttps://xn--rez-dma.fr/,Punycode Example,tag1\nhttps://rezé.fr/,UTF8 Example,tag2" }
+      let(:csv_content) { "url,tags\nhttps://xn--rez-dma.fr/,tag1\nhttps://rezé.fr/,tag2" }
 
       it "deduplicates normalized URLs and merges tags" do
         expect(parsed_data.length).to eq(1)
-        expect(parsed_data.first["name"]).to eq("UTF8 Example")
         expect(parsed_data.first["tag_names"]).to contain_exactly("tag1", "tag2")
       end
     end
 
     context "with blank lines" do
-      let(:csv_content) { "url,name\nhttps://example.com/,Example Site\n,\nhttps://test.com/,Test Site" }
+      let(:csv_content) { "url,\nhttps://example.com/\n,\nhttps://test.com/,Test Site" }
 
       it "ignores blank URLs" do
         expect(parsed_data.pluck("url")).to contain_exactly("https://example.com/", "https://test.com/")
@@ -87,7 +78,7 @@ RSpec.describe CsvSiteParser do
     end
 
     context "with invalid URLs" do
-      let(:csv_content) { "url,name\nhttps://example.com/,Example Site\nhttp://,Broken\n/contact,Relative\nhttps://test.com/,Test Site" }
+      let(:csv_content) { "url,\nhttps://example.com/\nhttp://,\n/contact\nhttps://test.com/" }
 
       it "continues parsing and collects invalid URL errors" do
         allow(Rails.logger).to receive(:warn)
@@ -100,7 +91,7 @@ RSpec.describe CsvSiteParser do
     end
 
     context "when CSV has nil headers" do
-      let(:csv_content) { "url,name,\nhttps://example.com/,Example Site,extra_data" }
+      let(:csv_content) { "url,\nhttps://example.com/,extra_data" }
 
       it "handles nil headers gracefully" do
         expect { parsed_data }.not_to raise_error
@@ -112,10 +103,10 @@ RSpec.describe CsvSiteParser do
   describe "#headers" do
     subject(:headers) { parser.headers }
 
-    let(:csv_content) { "URL;name\nhttps://example.com/;Example Site" }
+    let(:csv_content) { "URL\nhttps://example.com/" }
 
     it "returns lowercase headers" do
-      expect(headers).to eq(["url", "name"])
+      expect(headers).to eq(["url"])
     end
   end
 end

--- a/spec/services/site_batch_creation_service_spec.rb
+++ b/spec/services/site_batch_creation_service_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SiteBatchCreationService do
         process_site
 
         expect(created_site.url).to eq(url)
-        expect(created_site.name).to eq("New Name")
         expect(created_site.team).to eq(team)
       end
 
@@ -57,22 +56,11 @@ RSpec.describe SiteBatchCreationService do
           expect(site_tags).to contain_exactly("tag_1", "tag_2", "extra_tag")
         end
       end
-
-      context "when the CSV name is missing" do
-        let(:site_data) { { "url" => url, "tag_names" => [] } }
-
-        it "creates the site without a name" do
-          process_site
-
-          expect(created_site.name).to be_nil
-        end
-      end
     end
 
     context "when the site already exists" do
       let(:existing_tag) { create(:tag, team:, name: "existing_tag") }
-      let(:site_name) { "Original Name" }
-      let!(:existing_site) { create(:site, team:, url:, name: site_name, tags: [existing_tag]) }
+      let!(:existing_site) { create(:site, team:, url:, tags: [existing_tag]) }
 
       it "does not create a new site" do
         expect { process_site }.not_to change(Site, :count)
@@ -92,20 +80,6 @@ RSpec.describe SiteBatchCreationService do
         process_site
 
         expect(existing_site.last_audit.user).to eq(user)
-      end
-
-      context "when the site name is blank" do
-        let(:site_name) { "" }
-
-        it "updates the name from the CSV" do
-          expect { process_site }.to change { existing_site.reload.name }.from("").to("New Name")
-        end
-      end
-
-      context "when the site name is already present" do
-        it "does not overwrite the existing name" do
-          expect { process_site }.not_to change { existing_site.reload.name }
-        end
       end
 
       context "when a selected tag is already attached and present in the CSV" do


### PR DESCRIPTION
- Dropped `name` column from `sites` table
- Removed all usages of `name`
- Updated CSV exports and search filtering to use `normalized_url`