### PR TITLE
fix: user name is now displayed on /user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
 
   before_validation :find_or_create_team, on: :create
 
+  def to_s
+    name
+  end
+
   class << self
     def from_omniauth(auth)
       data_source = auth.info

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe UsersController do
       it "returns http success" do
         expect(response).to have_http_status(:success)
       end
+
+      it "displays the user name as the page title" do
+        expect(response.body).to have_selector("h1", exact_text: user.name)
+      end
     end
 
     context "when user is not authenticated" do


### PR DESCRIPTION
Petit fix sur une petite coquille qui est sur staging uniquement : 

Avant : 
<img width="823" height="208" alt="Capture d’écran 2026-07-21 à 17 04 53" src="https://github.com/user-attachments/assets/edfb4dc0-07f2-4645-b7ef-2e7aa38d2f8b" />

Apres : 
<img width="797" height="197" alt="Capture d’écran 2026-07-21 à 17 05 02" src="https://github.com/user-attachments/assets/bab23de8-e1b3-40ce-bd25-07214fb722ea" />
